### PR TITLE
Defer podcast RSS hydration after initial personalized load

### DIFF
--- a/lib/providers/library_provider.dart
+++ b/lib/providers/library_provider.dart
@@ -34,7 +34,11 @@ class LibraryProvider extends ChangeNotifier {
   Future<void>? _personalizedInFlight;
   DateTime? _lastPersonalizedFetchAt;
   String? _lastPersonalizedFetchLibraryId;
+  bool _rssHydrationInFlight = false;
+  DateTime? _lastRssHydrationAt;
+  String? _lastRssHydrationLibraryId;
   static const _personalizedFetchCooldown = Duration(seconds: 5);
+  static const _rssHydrationCooldown = Duration(minutes: 10);
 
   // Offline mode
   bool _manualOffline = false;
@@ -331,6 +335,9 @@ class LibraryProvider extends ChangeNotifier {
         _personalizedInFlight = null;
         _lastPersonalizedFetchAt = null;
         _lastPersonalizedFetchLibraryId = null;
+        _rssHydrationInFlight = false;
+        _lastRssHydrationAt = null;
+        _lastRssHydrationLibraryId = null;
         _networkOffline = false;
         _connectivitySub?.cancel();
         _stopServerPingTimer();
@@ -386,6 +393,9 @@ class LibraryProvider extends ChangeNotifier {
       _personalizedInFlight = null;
       _lastPersonalizedFetchAt = null;
       _lastPersonalizedFetchLibraryId = null;
+      _rssHydrationInFlight = false;
+      _lastRssHydrationAt = null;
+      _lastRssHydrationLibraryId = null;
       notifyListeners();
     }
   }
@@ -608,6 +618,11 @@ class LibraryProvider extends ChangeNotifier {
         }
       }
       await _updateAbsorbingCache();
+
+      // For podcast libraries, defer RSS-heavy fields until after first paint.
+      if (isPodcastLibrary) {
+        _hydrateRssFeedFieldsDeferred();
+      }
     } catch (e) {
       if (_isLikelyNetworkError(e)) {
         _goOffline();
@@ -618,6 +633,42 @@ class LibraryProvider extends ChangeNotifier {
 
     _isLoading = false;
     notifyListeners();
+  }
+
+  void _hydrateRssFeedFieldsDeferred() {
+    final api = _api;
+    final libraryId = _selectedLibraryId;
+    if (api == null || libraryId == null || isOffline) return;
+    if (_rssHydrationInFlight) return;
+
+    final now = DateTime.now();
+    if (_lastRssHydrationLibraryId == libraryId &&
+        _lastRssHydrationAt != null &&
+        now.difference(_lastRssHydrationAt!) < _rssHydrationCooldown) {
+      return;
+    }
+
+    _rssHydrationInFlight = true;
+    unawaited(() async {
+      try {
+        final sections = await api.getPersonalizedView(
+          libraryId,
+          include: const ['numEpisodesIncomplete', 'rssfeed'],
+        );
+        _lastRssHydrationAt = DateTime.now();
+        _lastRssHydrationLibraryId = libraryId;
+
+        if (_selectedLibraryId == libraryId && sections.isNotEmpty) {
+          _personalizedSections = sections;
+          await _updateAbsorbingCache();
+          notifyListeners();
+        }
+      } catch (_) {
+        // Non-critical; keep fast lightweight sections.
+      } finally {
+        _rssHydrationInFlight = false;
+      }
+    }());
   }
 
   Future<void> _refreshProgress() async {


### PR DESCRIPTION
## Summary
- Keep the initial personalized fetch lightweight for podcast libraries.
- Add deferred background hydration for RSS-heavy personalized fields (`rssfeed`) after first paint.
- Add cooldown and in-flight guards to avoid repeated RSS hydration calls.

## Why
Podcast personalized responses that include RSS-heavy fields can slow initial home load. Deferring that enrichment keeps startup responsive while still hydrating full data shortly after.

## Validation
- `flutter analyze lib/providers/library_provider.dart`