### PR TITLE
Reorder Discover ahead of Listen Again

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -199,8 +199,8 @@ class _HomeScreenState extends State<HomeScreen> {
     'continue-series',
     'episodes-recently-added',
     'recently-added',
-    'listen-again',
     'discover',
+    'listen-again',
   ];
 
   static const _hiddenSections = {'newest-authors', 'recent-series'};


### PR DESCRIPTION
## Summary
- move the Discover section ahead of Listen Again on the home screen

## Why
I find it odd that the discover would be under the fold when most people (I assume like me) would prefer to listen to something new