### PR TITLE
Improve stats page initial load performance

### DIFF
--- a/lib/screens/stats_screen.dart
+++ b/lib/screens/stats_screen.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
+import '../providers/library_provider.dart';
 import '../widgets/absorb_page_header.dart';
 import '../widgets/absorb_wave_icon.dart';
 
@@ -11,7 +12,8 @@ class StatsScreen extends StatefulWidget {
   State<StatsScreen> createState() => _StatsScreenState();
 }
 
-class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStateMixin {
+class _StatsScreenState extends State<StatsScreen>
+    with SingleTickerProviderStateMixin {
   Map<String, dynamic>? _stats;
   List<dynamic> _sessions = [];
   bool _isLoading = true;
@@ -22,8 +24,10 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
   @override
   void initState() {
     super.initState();
-    _animController = AnimationController(vsync: this, duration: const Duration(milliseconds: 1200));
-    _animValue = CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic);
+    _animController = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 1200));
+    _animValue =
+        CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic);
     _loadStats();
   }
 
@@ -35,33 +39,32 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
 
   Future<void> _loadStats() async {
     final api = context.read<AuthProvider>().apiService;
-    if (api == null) return;
-    final results = await Future.wait([
-      api.getListeningStats(),
-      api.getListeningSessions(itemsPerPage: 50),
-      api.getMe(),
-    ]);
-    final stats = results[0];
-    final sessionsData = results[1];
-    final meData = results[2];
-
-    int finished = 0;
-    if (meData != null) {
-      final progress = meData['mediaProgress'] as List<dynamic>? ?? [];
-      for (final p in progress) {
-        if (p is Map<String, dynamic> && p['isFinished'] == true) finished++;
-      }
+    final lib = context.read<LibraryProvider>();
+    if (api == null) {
+      if (mounted) setState(() => _isLoading = false);
+      return;
     }
+
+    // Phase 1: load core stats quickly so page can render fast.
+    final stats = await api.getListeningStats();
+    final finished = lib.finishedCount;
 
     if (mounted) {
       setState(() {
         _stats = stats;
-        _sessions = sessionsData?['sessions'] as List<dynamic>? ?? [];
         _booksFinished = finished;
         _isLoading = false;
       });
       _animController.reset();
       _animController.forward();
+    }
+
+    // Phase 2: load heavier sessions list in background.
+    final sessionsData = await api.getListeningSessions(itemsPerPage: 15);
+    if (mounted) {
+      setState(() {
+        _sessions = sessionsData?['sessions'] as List<dynamic>? ?? [];
+      });
     }
   }
 
@@ -88,7 +91,10 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
         ),
         child: SafeArea(
           child: _isLoading
-              ? Center(child: CircularProgressIndicator(strokeWidth: 2, color: cs.onSurface.withValues(alpha: 0.24)))
+              ? Center(
+                  child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: cs.onSurface.withValues(alpha: 0.24)))
               : _stats == null
                   ? _errorState(tt, cs)
                   : RefreshIndicator(
@@ -109,13 +115,21 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
   }
 
   Widget _errorState(TextTheme tt, ColorScheme cs) {
-    return Center(child: Column(mainAxisSize: MainAxisSize.min, children: [
-      Icon(Icons.signal_wifi_off_rounded, size: 48, color: cs.onSurface.withValues(alpha: 0.15)),
+    return Center(
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+      Icon(Icons.signal_wifi_off_rounded,
+          size: 48, color: cs.onSurface.withValues(alpha: 0.15)),
       const SizedBox(height: 12),
-      Text('Couldn\'t load stats', style: tt.bodyMedium?.copyWith(color: cs.onSurface.withValues(alpha: 0.38))),
+      Text('Couldn\'t load stats',
+          style: tt.bodyMedium
+              ?.copyWith(color: cs.onSurface.withValues(alpha: 0.38))),
       const SizedBox(height: 8),
-      TextButton(onPressed: () { setState(() => _isLoading = true); _loadStats(); },
-        child: const Text('Retry')),
+      TextButton(
+          onPressed: () {
+            setState(() => _isLoading = true);
+            _loadStats();
+          },
+          child: const Text('Retry')),
     ]));
   }
 
@@ -159,28 +173,32 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
         _sectionTitle(tt, cs, 'Activity'),
         const SizedBox(height: 10),
         Row(children: [
-          Expanded(child: _accentStatCard(tt, cs,
-            Icons.local_fire_department_rounded, Colors.orange,
-            '${streak}d', 'Current Streak')),
+          Expanded(
+              child: _accentStatCard(
+                  tt,
+                  cs,
+                  Icons.local_fire_department_rounded,
+                  Colors.orange,
+                  '${streak}d',
+                  'Current Streak')),
           const SizedBox(width: 8),
-          Expanded(child: _accentStatCard(tt, cs,
-            Icons.emoji_events_rounded, Colors.amber.shade600,
-            '${longestStreak}d', 'Best Streak')),
+          Expanded(
+              child: _accentStatCard(tt, cs, Icons.emoji_events_rounded,
+                  Colors.amber.shade600, '${longestStreak}d', 'Best Streak')),
         ]),
         const SizedBox(height: 8),
         Row(children: [
-          Expanded(child: _accentStatCard(tt, cs,
-            Icons.check_circle_rounded, Colors.green,
-            '$_booksFinished', 'Finished')),
+          Expanded(
+              child: _accentStatCard(tt, cs, Icons.check_circle_rounded,
+                  Colors.green, '$_booksFinished', 'Finished')),
           const SizedBox(width: 8),
-          Expanded(child: _accentStatCard(tt, cs,
-            Icons.calendar_today_rounded, cs.primary,
-            '$activeDays', 'Days Active')),
+          Expanded(
+              child: _accentStatCard(tt, cs, Icons.calendar_today_rounded,
+                  cs.primary, '$activeDays', 'Days Active')),
         ]),
         const SizedBox(height: 8),
-        _accentStatCard(tt, cs,
-          Icons.speed_rounded, cs.tertiary,
-          _formatDuration(avgDaily), 'Daily Average'),
+        _accentStatCard(tt, cs, Icons.speed_rounded, cs.tertiary,
+            _formatDuration(avgDaily), 'Daily Average'),
         const SizedBox(height: 28),
 
         // -- Last 7 days chart --
@@ -210,11 +228,12 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
   // --- SECTION TITLE ---
 
   Widget _sectionTitle(TextTheme tt, ColorScheme cs, String title) {
-    return Text(title, style: tt.titleSmall?.copyWith(
-      color: cs.onSurface.withValues(alpha: 0.5),
-      fontWeight: FontWeight.w600,
-      letterSpacing: 0.5,
-    ));
+    return Text(title,
+        style: tt.titleSmall?.copyWith(
+          color: cs.onSurface.withValues(alpha: 0.5),
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ));
   }
 
   // --- HERO STAT ---
@@ -229,7 +248,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(20),
         gradient: LinearGradient(
-          begin: Alignment.topLeft, end: Alignment.bottomRight,
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
           colors: [
             cs.primary.withValues(alpha: 0.12),
             cs.primary.withValues(alpha: 0.04),
@@ -238,34 +258,48 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
         border: Border.all(color: cs.primary.withValues(alpha: 0.15)),
       ),
       child: Column(children: [
-        Text('TOTAL LISTENING TIME', style: tt.labelSmall?.copyWith(
-          color: cs.onSurface.withValues(alpha: 0.35),
-          letterSpacing: 2,
-          fontWeight: FontWeight.w500,
-          fontSize: 10,
-        )),
+        Text('TOTAL LISTENING TIME',
+            style: tt.labelSmall?.copyWith(
+              color: cs.onSurface.withValues(alpha: 0.35),
+              letterSpacing: 2,
+              fontWeight: FontWeight.w500,
+              fontSize: 10,
+            )),
         const SizedBox(height: 14),
-        Row(mainAxisAlignment: MainAxisAlignment.center, crossAxisAlignment: CrossAxisAlignment.baseline,
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
           textBaseline: TextBaseline.alphabetic,
           children: [
             Text('${(hours * anim).round()}',
-              style: tt.displayLarge?.copyWith(
-                fontWeight: FontWeight.w800, color: cs.onSurface, fontSize: 52, height: 1)),
+                style: tt.displayLarge?.copyWith(
+                    fontWeight: FontWeight.w800,
+                    color: cs.onSurface,
+                    fontSize: 52,
+                    height: 1)),
             const SizedBox(width: 2),
-            Text('h', style: tt.titleLarge?.copyWith(
-              color: cs.onSurface.withValues(alpha: 0.3), fontWeight: FontWeight.w300)),
+            Text('h',
+                style: tt.titleLarge?.copyWith(
+                    color: cs.onSurface.withValues(alpha: 0.3),
+                    fontWeight: FontWeight.w300)),
             const SizedBox(width: 12),
             Text('${(minutes * anim).round()}',
-              style: tt.displayLarge?.copyWith(
-                fontWeight: FontWeight.w800, color: cs.onSurface, fontSize: 52, height: 1)),
+                style: tt.displayLarge?.copyWith(
+                    fontWeight: FontWeight.w800,
+                    color: cs.onSurface,
+                    fontSize: 52,
+                    height: 1)),
             const SizedBox(width: 2),
-            Text('m', style: tt.titleLarge?.copyWith(
-              color: cs.onSurface.withValues(alpha: 0.3), fontWeight: FontWeight.w300)),
+            Text('m',
+                style: tt.titleLarge?.copyWith(
+                    color: cs.onSurface.withValues(alpha: 0.3),
+                    fontWeight: FontWeight.w300)),
           ],
         ),
         const SizedBox(height: 10),
         Text(_daysEquivalent(totalSeconds),
-          style: tt.bodySmall?.copyWith(color: cs.onSurface.withValues(alpha: 0.25))),
+            style: tt.bodySmall
+                ?.copyWith(color: cs.onSurface.withValues(alpha: 0.25))),
       ]),
     );
   }
@@ -279,8 +313,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
 
   // --- ACCENT STAT CARD ---
 
-  Widget _accentStatCard(TextTheme tt, ColorScheme cs, IconData icon, Color accent,
-      String value, String label) {
+  Widget _accentStatCard(TextTheme tt, ColorScheme cs, IconData icon,
+      Color accent, String value, String label) {
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 14),
       decoration: BoxDecoration(
@@ -290,7 +324,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
       ),
       child: Row(children: [
         Container(
-          width: 36, height: 36,
+          width: 36,
+          height: 36,
           decoration: BoxDecoration(
             color: accent.withValues(alpha: 0.12),
             borderRadius: BorderRadius.circular(10),
@@ -298,12 +333,16 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
           child: Icon(icon, color: accent.withValues(alpha: 0.8), size: 18),
         ),
         const SizedBox(width: 12),
-        Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Text(value, style: tt.titleMedium?.copyWith(
-            fontWeight: FontWeight.w700, color: cs.onSurface, height: 1)),
+        Expanded(
+            child:
+                Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(value,
+              style: tt.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700, color: cs.onSurface, height: 1)),
           const SizedBox(height: 2),
-          Text(label, style: tt.labelSmall?.copyWith(
-            color: cs.onSurface.withValues(alpha: 0.35), fontSize: 11)),
+          Text(label,
+              style: tt.labelSmall?.copyWith(
+                  color: cs.onSurface.withValues(alpha: 0.35), fontSize: 11)),
         ])),
       ]),
     );
@@ -311,7 +350,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
 
   // --- PERIOD CARD ---
 
-  Widget _periodCard(TextTheme tt, ColorScheme cs, String label, double seconds) {
+  Widget _periodCard(
+      TextTheme tt, ColorScheme cs, String label, double seconds) {
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 10),
       decoration: BoxDecoration(
@@ -320,11 +360,13 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
         border: Border.all(color: cs.onSurface.withValues(alpha: 0.06)),
       ),
       child: Column(children: [
-        Text(_formatDuration(seconds), style: tt.titleMedium?.copyWith(
-          fontWeight: FontWeight.w700, color: cs.onSurface, height: 1)),
+        Text(_formatDuration(seconds),
+            style: tt.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700, color: cs.onSurface, height: 1)),
         const SizedBox(height: 4),
-        Text(label, style: tt.labelSmall?.copyWith(
-          color: cs.onSurface.withValues(alpha: 0.35), fontSize: 10)),
+        Text(label,
+            style: tt.labelSmall?.copyWith(
+                color: cs.onSurface.withValues(alpha: 0.35), fontSize: 10)),
       ]),
     );
   }
@@ -332,7 +374,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
   // --- BAR CHART (7 days) ---
 
   Widget _barChart(List<_DayData> data, ColorScheme cs, TextTheme tt) {
-    final maxVal = data.map((d) => d.seconds).fold(0.0, (a, b) => a > b ? a : b);
+    final maxVal =
+        data.map((d) => d.seconds).fold(0.0, (a, b) => a > b ? a : b);
     final barMax = maxVal > 0 ? maxVal : 1.0;
     final anim = _animValue.value;
 
@@ -351,13 +394,19 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
             children: data.map((d) {
               final ratio = (d.seconds / barMax * anim).clamp(0.0, 1.0);
               final isToday = d.fullLabel == _dateKey(DateTime.now());
-              return Expanded(child: Padding(
+              return Expanded(
+                  child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 3),
-                child: Column(mainAxisAlignment: MainAxisAlignment.end, children: [
+                child:
+                    Column(mainAxisAlignment: MainAxisAlignment.end, children: [
                   if (d.seconds > 0)
-                    Padding(padding: const EdgeInsets.only(bottom: 4),
-                      child: Text(_shortDuration(d.seconds), style: TextStyle(
-                        color: cs.onSurface.withValues(alpha: 0.35), fontSize: 9, fontWeight: FontWeight.w600))),
+                    Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Text(_shortDuration(d.seconds),
+                            style: TextStyle(
+                                color: cs.onSurface.withValues(alpha: 0.35),
+                                fontSize: 9,
+                                fontWeight: FontWeight.w600))),
                   Container(
                     height: max(ratio * 80, d.seconds > 0 ? 4 : 2),
                     decoration: BoxDecoration(
@@ -373,14 +422,19 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
           ),
         ),
         const SizedBox(height: 8),
-        Row(children: data.map((d) {
+        Row(
+            children: data.map((d) {
           final isToday = d.fullLabel == _dateKey(DateTime.now());
-          return Expanded(child: Text(d.label, textAlign: TextAlign.center,
-            style: TextStyle(
-              color: isToday ? cs.primary.withValues(alpha: 0.8) : cs.onSurface.withValues(alpha: 0.25),
-              fontSize: 10,
-              fontWeight: isToday ? FontWeight.w600 : FontWeight.w400,
-            )));
+          return Expanded(
+              child: Text(d.label,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: isToday
+                        ? cs.primary.withValues(alpha: 0.8)
+                        : cs.onSurface.withValues(alpha: 0.25),
+                    fontSize: 10,
+                    fontWeight: isToday ? FontWeight.w600 : FontWeight.w400,
+                  )));
         }).toList()),
       ]),
     );
@@ -408,7 +462,11 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
         existing.totalSeconds += duration;
         existing.sessionCount++;
       } else {
-        byTitle[title] = _TopItem(title: title, author: author, totalSeconds: duration, sessionCount: 1);
+        byTitle[title] = _TopItem(
+            title: title,
+            author: author,
+            totalSeconds: duration,
+            sessionCount: 1);
       }
     }
     final items = byTitle.values.toList()
@@ -427,22 +485,34 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
           border: Border.all(color: cs.onSurface.withValues(alpha: 0.05)),
         ),
         child: Row(children: [
-          Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-            Text(item.title, maxLines: 1, overflow: TextOverflow.ellipsis,
-              style: tt.bodySmall?.copyWith(
-                color: cs.onSurface.withValues(alpha: 0.8), fontWeight: FontWeight.w600)),
-            if (item.author.isNotEmpty)
-              Text(item.author, maxLines: 1, overflow: TextOverflow.ellipsis,
-                style: tt.labelSmall?.copyWith(
-                  color: cs.onSurface.withValues(alpha: 0.3), fontSize: 10)),
-          ])),
+          Expanded(
+              child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                Text(item.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: tt.bodySmall?.copyWith(
+                        color: cs.onSurface.withValues(alpha: 0.8),
+                        fontWeight: FontWeight.w600)),
+                if (item.author.isNotEmpty)
+                  Text(item.author,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: tt.labelSmall?.copyWith(
+                          color: cs.onSurface.withValues(alpha: 0.3),
+                          fontSize: 10)),
+              ])),
           const SizedBox(width: 12),
           Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
             Text(_formatDuration(item.totalSeconds),
-              style: tt.labelSmall?.copyWith(
-                color: cs.onSurface.withValues(alpha: 0.5), fontWeight: FontWeight.w700)),
-            Text('${item.sessionCount} ${item.sessionCount == 1 ? 'session' : 'sessions'}',
-              style: TextStyle(color: cs.onSurface.withValues(alpha: 0.2), fontSize: 9)),
+                style: tt.labelSmall?.copyWith(
+                    color: cs.onSurface.withValues(alpha: 0.5),
+                    fontWeight: FontWeight.w700)),
+            Text(
+                '${item.sessionCount} ${item.sessionCount == 1 ? 'session' : 'sessions'}',
+                style: TextStyle(
+                    color: cs.onSurface.withValues(alpha: 0.2), fontSize: 9)),
           ]),
         ]),
       ),
@@ -458,9 +528,11 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
       final rawAuthor = s['displayAuthor'] as String?;
       final meta = s['mediaMetadata'] as Map<String, dynamic>?;
       final title = (rawTitle != null && !_looksLikeId(rawTitle))
-          ? rawTitle : meta?['title'] as String? ?? 'Unknown';
+          ? rawTitle
+          : meta?['title'] as String? ?? 'Unknown';
       final author = (rawAuthor != null && !_looksLikeId(rawAuthor))
-          ? rawAuthor : meta?['authorName'] as String? ?? '';
+          ? rawAuthor
+          : meta?['authorName'] as String? ?? '';
       final duration = _safeNum(s['timeListening']);
       final updatedAt = s['updatedAt'] is num
           ? DateTime.fromMillisecondsSinceEpoch((s['updatedAt'] as num).toInt())
@@ -468,7 +540,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
 
       final deviceInfo = s['deviceInfo'] as Map<String, dynamic>? ?? {};
       final clientName = deviceInfo['clientName'] as String? ??
-          deviceInfo['deviceName'] as String? ?? '';
+          deviceInfo['deviceName'] as String? ??
+          '';
       final isAbsorb = clientName.toLowerCase().contains('absorb');
 
       return Padding(
@@ -482,35 +555,55 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
           ),
           child: Row(children: [
             Container(
-              width: 32, height: 32,
+              width: 32,
+              height: 32,
               decoration: BoxDecoration(
-                color: (isAbsorb ? Colors.tealAccent : cs.onSurfaceVariant).withValues(alpha: 0.12),
+                color: (isAbsorb ? Colors.tealAccent : cs.onSurfaceVariant)
+                    .withValues(alpha: 0.12),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Center(
                 child: isAbsorb
-                    ? AbsorbWaveIcon(size: 16, color: Colors.tealAccent.withValues(alpha: 0.7))
-                    : Icon(_clientIcon(clientName), size: 15,
+                    ? AbsorbWaveIcon(
+                        size: 16,
+                        color: Colors.tealAccent.withValues(alpha: 0.7))
+                    : Icon(_clientIcon(clientName),
+                        size: 15,
                         color: cs.onSurfaceVariant.withValues(alpha: 0.6)),
               ),
             ),
             const SizedBox(width: 10),
-            Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              Text(title, maxLines: 1, overflow: TextOverflow.ellipsis,
-                style: tt.bodySmall?.copyWith(
-                  color: cs.onSurface.withValues(alpha: 0.7), fontWeight: FontWeight.w600, fontSize: 12)),
-              if (author.isNotEmpty)
-                Text(author, maxLines: 1, overflow: TextOverflow.ellipsis,
-                  style: TextStyle(color: cs.onSurface.withValues(alpha: 0.25), fontSize: 10)),
-            ])),
+            Expanded(
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                  Text(title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: tt.bodySmall?.copyWith(
+                          color: cs.onSurface.withValues(alpha: 0.7),
+                          fontWeight: FontWeight.w600,
+                          fontSize: 12)),
+                  if (author.isNotEmpty)
+                    Text(author,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                            color: cs.onSurface.withValues(alpha: 0.25),
+                            fontSize: 10)),
+                ])),
             const SizedBox(width: 8),
             Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
               Text(_formatDuration(duration),
-                style: tt.labelSmall?.copyWith(
-                  color: cs.onSurface.withValues(alpha: 0.4), fontWeight: FontWeight.w600, fontSize: 11)),
+                  style: tt.labelSmall?.copyWith(
+                      color: cs.onSurface.withValues(alpha: 0.4),
+                      fontWeight: FontWeight.w600,
+                      fontSize: 11)),
               if (updatedAt != null)
                 Text(_relativeDate(updatedAt),
-                  style: TextStyle(color: cs.onSurface.withValues(alpha: 0.18), fontSize: 9)),
+                    style: TextStyle(
+                        color: cs.onSurface.withValues(alpha: 0.18),
+                        fontSize: 9)),
             ]),
           ]),
         ),
@@ -520,11 +613,15 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
 
   IconData _clientIcon(String clientName) {
     final lower = clientName.toLowerCase();
-    if (lower.contains('audiobookshelf') || lower.contains('abs')) return Icons.headphones_rounded;
-    if (lower.contains('web') || lower.contains('browser')) return Icons.language_rounded;
-    if (lower.contains('ios') || lower.contains('apple')) return Icons.phone_iphone_rounded;
+    if (lower.contains('audiobookshelf') || lower.contains('abs'))
+      return Icons.headphones_rounded;
+    if (lower.contains('web') || lower.contains('browser'))
+      return Icons.language_rounded;
+    if (lower.contains('ios') || lower.contains('apple'))
+      return Icons.phone_iphone_rounded;
     if (lower.contains('android')) return Icons.phone_android_rounded;
-    if (lower.contains('sonos') || lower.contains('cast')) return Icons.speaker_rounded;
+    if (lower.contains('sonos') || lower.contains('cast'))
+      return Icons.speaker_rounded;
     return Icons.devices_rounded;
   }
 
@@ -582,7 +679,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
     final now = DateTime.now();
     int startOffset = _daySeconds(dailyMap, _dateKey(now)) > 0 ? 0 : 1;
     for (int i = startOffset; i < 365; i++) {
-      if (_daySeconds(dailyMap, _dateKey(now.subtract(Duration(days: i)))) > 0) {
+      if (_daySeconds(dailyMap, _dateKey(now.subtract(Duration(days: i)))) >
+          0) {
         streak++;
       } else {
         break;
@@ -624,7 +722,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
     double total = 0;
     int daysWithData = 0;
     for (int i = 0; i < 30; i++) {
-      final s = _daySeconds(dailyMap, _dateKey(now.subtract(Duration(days: i))));
+      final s =
+          _daySeconds(dailyMap, _dateKey(now.subtract(Duration(days: i))));
       if (s > 0) {
         total += s;
         daysWithData++;
@@ -648,7 +747,8 @@ class _StatsScreenState extends State<StatsScreen> with SingleTickerProviderStat
   String _dateKey(DateTime d) =>
       '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 
-  String _dayLabel(DateTime d) => ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][d.weekday - 1];
+  String _dayLabel(DateTime d) =>
+      ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][d.weekday - 1];
 
   String _formatDuration(double seconds) {
     final h = (seconds / 3600).floor();
@@ -679,7 +779,8 @@ class _DayData {
   final String label;
   final String fullLabel;
   final double seconds;
-  const _DayData({required this.label, required this.fullLabel, required this.seconds});
+  const _DayData(
+      {required this.label, required this.fullLabel, required this.seconds});
 }
 
 class _TopItem {
@@ -687,5 +788,9 @@ class _TopItem {
   final String author;
   double totalSeconds;
   int sessionCount;
-  _TopItem({required this.title, required this.author, required this.totalSeconds, required this.sessionCount});
+  _TopItem(
+      {required this.title,
+      required this.author,
+      required this.totalSeconds,
+      required this.sessionCount});
 }


### PR DESCRIPTION
## Summary
- load the core stats payload first so the stats screen can render sooner
- defer recent sessions loading into a follow-up background step

## Why
The stats page currently waits on heavier secondary data before painting, which makes opening it feel slower than necessary.