### PR TITLE
[Feature] ReadMeABook Admin Approvals + Request Notifications

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -28,7 +28,9 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
+  # Static linkage so background_fetch's statically-linked TSBackgroundFetch
+  # xcframework can coexist with the other CocoaPods frameworks.
+  use_frameworks! :linkage => :static
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -82,6 +82,10 @@
 			<string>audio</string>
 			<string>fetch</string>
 		</array>
+		<key>BGTaskSchedulerPermittedIdentifiers</key>
+		<array>
+			<string>com.transistorsoft.fetch</string>
+		</array>
 		<key>NSAppTransportSecurity</key>
 		<dict>
 			<key>NSAllowsArbitraryLoads</key>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1121,6 +1121,26 @@
   "rmabApprovalsEmpty": "No requests awaiting approval",
   "rmabApprovalsError": "Couldn't load approvals",
   "rmabApprovalForbidden": "This token isn't allowed to review approvals",
+  "rmabApprovalNotifsTitle": "Approval notifications",
+  "rmabApprovalNotifsSubtitle": "Notify me when new requests need approval. Best-effort in the background.",
+  "rmabApprovalNotifsDenied": "Notification permission was denied",
+  "rmabApprovalNotifTitle": "Approvals waiting",
+  "rmabApprovalNotifBodyOne": "“{title}” needs your approval",
+  "@rmabApprovalNotifBodyOne": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "rmabApprovalNotifBodyMany": "{count} requests need your approval",
+  "@rmabApprovalNotifBodyMany": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "rmabApprovalApprove": "Approve",
   "rmabApprovalDeny": "Deny",
   "rmabApprovalApproved": "Request approved",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1109,6 +1109,31 @@
   "rmabMyRequestsEmpty": "You haven't requested any books yet",
   "rmabMyRequestsError": "Couldn't load requests",
   "rmabMyRequestsRefresh": "Refresh",
+  "rmabApprovalsTab": "Approvals",
+  "rmabApprovalsEmpty": "No requests awaiting approval",
+  "rmabApprovalsError": "Couldn't load approvals",
+  "rmabApprovalForbidden": "This token isn't allowed to review approvals",
+  "rmabApprovalApprove": "Approve",
+  "rmabApprovalDeny": "Deny",
+  "rmabApprovalApproved": "Request approved",
+  "rmabApprovalDenied": "Request denied",
+  "rmabApprovalRequestedBy": "Requested by {name}",
+  "@rmabApprovalRequestedBy": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "rmabApprovalDenyConfirmTitle": "Deny this request?",
+  "rmabApprovalDenyConfirmBody": "“{title}” won't be downloaded and the requester will be notified.",
+  "@rmabApprovalDenyConfirmBody": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "rmabRequestDetailTitle": "Request details",
   "rmabRequestDetailStatus": "Status",
   "rmabRequestDetailRequestedOn": "Requested on",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1044,6 +1044,14 @@
   "adminRmabLoadFailed": "Couldn't load ReadMeABook. Check your URL.",
   "adminRmabConnected": "Connected",
   "adminRmabAskAdmin": "Get a login URL from your server admin",
+  "adminRmabApprovalsPending": "{count, plural, =1{1 request awaiting approval} other{{count} requests awaiting approval}}",
+  "@adminRmabApprovalsPending": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "adminRmabUrlHelpUser": "Get a login URL from your server admin. They generate one in RMAB > Admin > Users.",
   "adminRmabSettingsInfo": "ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.",
   "rmabConfigTitle": "Connect ReadMeABook",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3766,6 +3766,12 @@ abstract class AppLocalizations {
   /// **'Get a login URL from your server admin'**
   String get adminRmabAskAdmin;
 
+  /// No description provided for @adminRmabApprovalsPending.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 request awaiting approval} other{{count} requests awaiting approval}}'**
+  String adminRmabApprovalsPending(int count);
+
   /// No description provided for @adminRmabUrlHelpUser.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -72,7 +72,8 @@ import 'app_localizations_zh.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -80,7 +81,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -92,7 +94,8 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -5831,7 +5834,8 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{start} – {end} · {duration}'**
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration);
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration);
 
   /// No description provided for @endOfChapterShort.
   ///
@@ -8213,7 +8217,8 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{month} {day}, {year} at {hour}:{minute} {ampm}'**
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm);
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm);
 
   /// No description provided for @statsScreenMonthJan.
   ///
@@ -11390,7 +11395,8 @@ abstract class AppLocalizations {
   String get libRemoveFoldersBody;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -11399,35 +11405,57 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['de', 'el', 'en', 'es', 'fr', 'it', 'ja', 'no', 'pt', 'ro', 'ru', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+        'de',
+        'el',
+        'en',
+        'es',
+        'fr',
+        'it',
+        'ja',
+        'no',
+        'pt',
+        'ro',
+        'ru',
+        'zh'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
-
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'de': return AppLocalizationsDe();
-    case 'el': return AppLocalizationsEl();
-    case 'en': return AppLocalizationsEn();
-    case 'es': return AppLocalizationsEs();
-    case 'fr': return AppLocalizationsFr();
-    case 'it': return AppLocalizationsIt();
-    case 'ja': return AppLocalizationsJa();
-    case 'no': return AppLocalizationsNo();
-    case 'pt': return AppLocalizationsPt();
-    case 'ro': return AppLocalizationsRo();
-    case 'ru': return AppLocalizationsRu();
-    case 'zh': return AppLocalizationsZh();
+    case 'de':
+      return AppLocalizationsDe();
+    case 'el':
+      return AppLocalizationsEl();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'es':
+      return AppLocalizationsEs();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'it':
+      return AppLocalizationsIt();
+    case 'ja':
+      return AppLocalizationsJa();
+    case 'no':
+      return AppLocalizationsNo();
+    case 'pt':
+      return AppLocalizationsPt();
+    case 'ro':
+      return AppLocalizationsRo();
+    case 'ru':
+      return AppLocalizationsRu();
+    case 'zh':
+      return AppLocalizationsZh();
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4072,6 +4072,72 @@ abstract class AppLocalizations {
   /// **'Refresh'**
   String get rmabMyRequestsRefresh;
 
+  /// No description provided for @rmabApprovalsTab.
+  ///
+  /// In en, this message translates to:
+  /// **'Approvals'**
+  String get rmabApprovalsTab;
+
+  /// No description provided for @rmabApprovalsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No requests awaiting approval'**
+  String get rmabApprovalsEmpty;
+
+  /// No description provided for @rmabApprovalsError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load approvals'**
+  String get rmabApprovalsError;
+
+  /// No description provided for @rmabApprovalForbidden.
+  ///
+  /// In en, this message translates to:
+  /// **'This token isn\'t allowed to review approvals'**
+  String get rmabApprovalForbidden;
+
+  /// No description provided for @rmabApprovalApprove.
+  ///
+  /// In en, this message translates to:
+  /// **'Approve'**
+  String get rmabApprovalApprove;
+
+  /// No description provided for @rmabApprovalDeny.
+  ///
+  /// In en, this message translates to:
+  /// **'Deny'**
+  String get rmabApprovalDeny;
+
+  /// No description provided for @rmabApprovalApproved.
+  ///
+  /// In en, this message translates to:
+  /// **'Request approved'**
+  String get rmabApprovalApproved;
+
+  /// No description provided for @rmabApprovalDenied.
+  ///
+  /// In en, this message translates to:
+  /// **'Request denied'**
+  String get rmabApprovalDenied;
+
+  /// No description provided for @rmabApprovalRequestedBy.
+  ///
+  /// In en, this message translates to:
+  /// **'Requested by {name}'**
+  String rmabApprovalRequestedBy(String name);
+
+  /// No description provided for @rmabApprovalDenyConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Deny this request?'**
+  String get rmabApprovalDenyConfirmTitle;
+
+  /// No description provided for @rmabApprovalDenyConfirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'“{title}” won\'t be downloaded and the requester will be notified.'**
+  String rmabApprovalDenyConfirmBody(String title);
+
   /// No description provided for @rmabRequestDetailTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -72,8 +72,7 @@ import 'app_localizations_zh.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -81,8 +80,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -94,8 +92,7 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -4102,6 +4099,42 @@ abstract class AppLocalizations {
   /// **'This token isn\'t allowed to review approvals'**
   String get rmabApprovalForbidden;
 
+  /// No description provided for @rmabApprovalNotifsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Approval notifications'**
+  String get rmabApprovalNotifsTitle;
+
+  /// No description provided for @rmabApprovalNotifsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Notify me when new requests need approval. Best-effort in the background.'**
+  String get rmabApprovalNotifsSubtitle;
+
+  /// No description provided for @rmabApprovalNotifsDenied.
+  ///
+  /// In en, this message translates to:
+  /// **'Notification permission was denied'**
+  String get rmabApprovalNotifsDenied;
+
+  /// No description provided for @rmabApprovalNotifTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Approvals waiting'**
+  String get rmabApprovalNotifTitle;
+
+  /// No description provided for @rmabApprovalNotifBodyOne.
+  ///
+  /// In en, this message translates to:
+  /// **'“{title}” needs your approval'**
+  String rmabApprovalNotifBodyOne(String title);
+
+  /// No description provided for @rmabApprovalNotifBodyMany.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} requests need your approval'**
+  String rmabApprovalNotifBodyMany(int count);
+
   /// No description provided for @rmabApprovalApprove.
   ///
   /// In en, this message translates to:
@@ -5798,8 +5831,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{start} – {end} · {duration}'**
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration);
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration);
 
   /// No description provided for @endOfChapterShort.
   ///
@@ -8181,8 +8213,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{month} {day}, {year} at {hour}:{minute} {ampm}'**
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm);
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm);
 
   /// No description provided for @statsScreenMonthJan.
   ///
@@ -11359,8 +11390,7 @@ abstract class AppLocalizations {
   String get libRemoveFoldersBody;
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -11369,57 +11399,35 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) => <String>[
-        'de',
-        'el',
-        'en',
-        'es',
-        'fr',
-        'it',
-        'ja',
-        'no',
-        'pt',
-        'ro',
-        'ru',
-        'zh'
-      ].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['de', 'el', 'en', 'es', 'fr', 'it', 'ja', 'no', 'pt', 'ro', 'ru', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'de':
-      return AppLocalizationsDe();
-    case 'el':
-      return AppLocalizationsEl();
-    case 'en':
-      return AppLocalizationsEn();
-    case 'es':
-      return AppLocalizationsEs();
-    case 'fr':
-      return AppLocalizationsFr();
-    case 'it':
-      return AppLocalizationsIt();
-    case 'ja':
-      return AppLocalizationsJa();
-    case 'no':
-      return AppLocalizationsNo();
-    case 'pt':
-      return AppLocalizationsPt();
-    case 'ro':
-      return AppLocalizationsRo();
-    case 'ru':
-      return AppLocalizationsRu();
-    case 'zh':
-      return AppLocalizationsZh();
+    case 'de': return AppLocalizationsDe();
+    case 'el': return AppLocalizationsEl();
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
+    case 'fr': return AppLocalizationsFr();
+    case 'it': return AppLocalizationsIt();
+    case 'ja': return AppLocalizationsJa();
+    case 'no': return AppLocalizationsNo();
+    case 'pt': return AppLocalizationsPt();
+    case 'ro': return AppLocalizationsRo();
+    case 'ru': return AppLocalizationsRu();
+    case 'zh': return AppLocalizationsZh();
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -18,7 +18,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get offline => 'Offline';
 
   @override
-  String get stillOffline => 'Immer noch offline. Tippe, um es erneut zu versuchen.';
+  String get stillOffline =>
+      'Immer noch offline. Tippe, um es erneut zu versuchen.';
 
   @override
   String get retry => 'Erneut versuchen';
@@ -120,13 +121,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Deine Bibliothek ist leer';
 
   @override
-  String get downloadBooksWhileOnline => 'Lade Bücher herunter, solange du online bist, um sie offline zu hören';
+  String get downloadBooksWhileOnline =>
+      'Lade Bücher herunter, solange du online bist, um sie offline zu hören';
 
   @override
   String get customizeHome => 'Startseite anpassen';
 
   @override
-  String get dragToReorderTapEye => 'Zum Umsortieren ziehen, Auge antippen zum Ein-/Ausblenden';
+  String get dragToReorderTapEye =>
+      'Zum Umsortieren ziehen, Auge antippen zum Ein-/Ausblenden';
 
   @override
   String get loginTagline => 'Start Absorbing';
@@ -141,7 +144,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginServerHint => 'my.server.com';
 
   @override
-  String get loginServerHelper => 'IP:Port funktioniert auch (z. B. 192.168.1.5:13378)';
+  String get loginServerHelper =>
+      'IP:Port funktioniert auch (z. B. 192.168.1.5:13378)';
 
   @override
   String get loginCouldNotReachServer => 'Server nicht erreichbar';
@@ -153,7 +157,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Eigene HTTP-Header';
 
   @override
-  String get loginCustomHeadersDescription => 'Für Cloudflare-Tunnel oder Reverse-Proxys, die zusätzliche Header benötigen. Header hinzufügen, bevor du die Server-URL eingibst.';
+  String get loginCustomHeadersDescription =>
+      'Für Cloudflare-Tunnel oder Reverse-Proxys, die zusätzliche Header benötigen. Header hinzufügen, bevor du die Server-URL eingibst.';
 
   @override
   String get loginHeaderName => 'Header-Name';
@@ -168,13 +173,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Selbstsignierte Zertifikate';
 
   @override
-  String get loginTrustAllCertificates => 'Allen Zertifikaten vertrauen (für selbstsignierte / eigene CA-Setups)';
+  String get loginTrustAllCertificates =>
+      'Allen Zertifikaten vertrauen (für selbstsignierte / eigene CA-Setups)';
 
   @override
   String get loginApiKey => 'API-Schlüssel';
 
   @override
-  String get loginApiKeyDescription => 'Verwende einen vom Admin generierten API-Schlüssel statt Benutzername/Passwort. Praktisch, wenn die Token-Erneuerung für dein Konto fehlschlägt.';
+  String get loginApiKeyDescription =>
+      'Verwende einen vom Admin generierten API-Schlüssel statt Benutzername/Passwort. Praktisch, wenn die Token-Erneuerung für dein Konto fehlschlägt.';
 
   @override
   String get loginWaitingForSso => 'Warte auf SSO...';
@@ -222,10 +229,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +243,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +263,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginSsoFailed => 'SSO-Anmeldung fehlgeschlagen oder abgebrochen';
 
   @override
-  String get loginSsoAuthFailed => 'SSO-Authentifizierung fehlgeschlagen. Bitte versuche es erneut.';
+  String get loginSsoAuthFailed =>
+      'SSO-Authentifizierung fehlgeschlagen. Bitte versuche es erneut.';
 
   @override
   String get loginRestoreFromBackup => 'Aus Backup wiederherstellen';
@@ -270,7 +281,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'Damit werden alle Einstellungen wiederhergestellt. Es waren keine Konten in diesem Backup enthalten.';
+  String get loginRestoreBackupNoAccounts =>
+      'Damit werden alle Einstellungen wiederhergestellt. Es waren keine Konten in diesem Backup enthalten.';
 
   @override
   String get loginRestore => 'Wiederherstellen';
@@ -281,7 +293,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Einstellungen wiederhergestellt. Sitzung abgelaufen - melde dich an, um fortzufahren.';
+  String get loginSessionExpired =>
+      'Einstellungen wiederhergestellt. Sitzung abgelaufen - melde dich an, um fortzufahren.';
 
   @override
   String get loginSettingsRestored => 'Einstellungen wiederhergestellt';
@@ -298,7 +311,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libraryTitle => 'Bibliothek';
 
   @override
-  String get librarySearchBooksHint => 'Bücher, Serien, Autoren, Sprecher suchen...';
+  String get librarySearchBooksHint =>
+      'Bücher, Serien, Autoren, Sprecher suchen...';
 
   @override
   String get librarySearchShowsHint => 'Sendungen und Episoden suchen...';
@@ -484,7 +498,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get absorbingDone => 'Fertig';
 
   @override
-  String get absorbingNoDownloadedEpisodes => 'Keine heruntergeladenen Episoden';
+  String get absorbingNoDownloadedEpisodes =>
+      'Keine heruntergeladenen Episoden';
 
   @override
   String get absorbingNoDownloadedBooks => 'Keine heruntergeladenen Bücher';
@@ -496,16 +511,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Noch nichts am Absorbing';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Episoden herunterladen, um offline zu hören';
+  String get absorbingDownloadEpisodesToListen =>
+      'Episoden herunterladen, um offline zu hören';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Bücher herunterladen, um offline zu hören';
+  String get absorbingDownloadBooksToListen =>
+      'Bücher herunterladen, um offline zu hören';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Starte eine Episode aus dem Sendungen-Tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Starte eine Episode aus dem Sendungen-Tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Starte ein Buch aus dem Bibliothek-Tab';
+  String get absorbingStartBookFromLibrary =>
+      'Starte ein Buch aus dem Bibliothek-Tab';
 
   @override
   String get carModeTitle => 'Auto-Modus';
@@ -561,7 +580,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Heruntergeladene Dateien werden von diesem Gerät entfernt.';
+  String get downloadsDeleteContent =>
+      'Heruntergeladene Dateien werden von diesem Gerät entfernt.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -610,7 +630,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get bookmarksDeleteContent => 'Das kann nicht rückgängig gemacht werden.';
+  String get bookmarksDeleteContent =>
+      'Das kann nicht rückgängig gemacht werden.';
 
   @override
   String bookmarksDeletedCount(int count) {
@@ -892,7 +913,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get languageSystemDefault => 'Systemstandard';
 
   @override
-  String get languageHelpTranslateInvite => 'Möchtest du Absorb in deine Sprache übersetzen?';
+  String get languageHelpTranslateInvite =>
+      'Möchtest du Absorb in deine Sprache übersetzen?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +935,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get colorSourceLabel => 'Farbquelle';
 
   @override
-  String get colorSourceCoverDescription => 'App-Farben richten sich nach dem Cover des aktuell laufenden Buchs';
+  String get colorSourceCoverDescription =>
+      'App-Farben richten sich nach dem Cover des aktuell laufenden Buchs';
 
   @override
-  String get colorSourceWallpaperDescription => 'App-Farben richten sich nach deinem System-Hintergrundbild';
+  String get colorSourceWallpaperDescription =>
+      'App-Farben richten sich nach deinem System-Hintergrundbild';
 
   @override
   String get colorSourceWallpaper => 'Hintergrundbild';
@@ -931,7 +955,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +965,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -955,7 +982,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get startScreenLabel => 'Startbildschirm';
 
   @override
-  String get startScreenSubtitle => 'Welcher Tab beim Start der App geöffnet wird';
+  String get startScreenSubtitle =>
+      'Welcher Tab beim Start der App geöffnet wird';
 
   @override
   String get startScreenHome => 'Start';
@@ -976,7 +1004,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get disablePageFadeOnSubtitle => 'Seiten wechseln sofort';
 
   @override
-  String get disablePageFadeOffSubtitle => 'Seiten blenden beim Tab-Wechsel über';
+  String get disablePageFadeOffSubtitle =>
+      'Seiten blenden beim Tab-Wechsel über';
 
   @override
   String get rectangleBookCovers => 'Rechteckige Buchcover';
@@ -985,7 +1014,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Cover werden im 2:3-Buchformat angezeigt';
+  String get rectangleBookCoversOnSubtitle =>
+      'Cover werden im 2:3-Buchformat angezeigt';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Cover sind quadratisch';
@@ -997,16 +1027,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fullScreenPlayer => 'Vollbild-Player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'An - Bücher öffnen sich beim Abspielen im Vollbild';
+  String get fullScreenPlayerOnSubtitle =>
+      'An - Bücher öffnen sich beim Abspielen im Vollbild';
 
   @override
-  String get fullScreenPlayerOffSubtitle => 'Aus - Wiedergabe in der Kartenansicht';
+  String get fullScreenPlayerOffSubtitle =>
+      'Aus - Wiedergabe in der Kartenansicht';
 
   @override
   String get fullBookScrubber => 'Ganzes-Buch-Scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'An - durchziehbarer Slider über das gesamte Buch';
+  String get fullBookScrubberOnSubtitle =>
+      'An - durchziehbarer Slider über das gesamte Buch';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Aus - nur Fortschrittsbalken';
@@ -1015,7 +1048,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get speedAdjustedTime => 'Geschwindigkeitsangepasste Zeit';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'An - verbleibende Zeit berücksichtigt die Wiedergabegeschwindigkeit';
+  String get speedAdjustedTimeOnSubtitle =>
+      'An - verbleibende Zeit berücksichtigt die Wiedergabegeschwindigkeit';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Aus - zeigt die reine Audiodauer';
@@ -1024,7 +1058,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get buttonLayout => 'Button-Anordnung';
 
   @override
-  String get buttonLayoutSubtitle => 'Wie die Aktions-Buttons auf der Karte angeordnet sind';
+  String get buttonLayoutSubtitle =>
+      'Wie die Aktions-Buttons auf der Karte angeordnet sind';
 
   @override
   String get whenAbsorbed => 'Beim Absorb';
@@ -1033,10 +1068,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'Beim Absorb';
 
   @override
-  String get whenAbsorbedInfoContent => 'Steuert, was mit einer Absorbing-Karte passiert, wenn du ein Buch oder eine Episode beendest.\n\nBeendete Karten werden automatisch von deinem Absorbing-Bildschirm entfernt.';
+  String get whenAbsorbedInfoContent =>
+      'Steuert, was mit einer Absorbing-Karte passiert, wenn du ein Buch oder eine Episode beendest.\n\nBeendete Karten werden automatisch von deinem Absorbing-Bildschirm entfernt.';
 
   @override
-  String get whenAbsorbedSubtitle => 'Was mit der Absorbing-Karte passiert, wenn ein Buch oder eine Episode endet';
+  String get whenAbsorbedSubtitle =>
+      'Was mit der Absorbing-Karte passiert, wenn ein Buch oder eine Episode endet';
 
   @override
   String get whenAbsorbedShowOverlay => 'Overlay anzeigen';
@@ -1051,13 +1088,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Bibliotheken zusammenführen';
 
   @override
-  String get mergeLibrariesInfoContent => 'Wenn aktiviert, zeigt der Absorbing-Bildschirm alle deine angefangenen Bücher und Podcasts aus jeder Bibliothek in einer Ansicht. Wenn deaktiviert, werden nur Inhalte aus der aktuell ausgewählten Bibliothek angezeigt.';
+  String get mergeLibrariesInfoContent =>
+      'Wenn aktiviert, zeigt der Absorbing-Bildschirm alle deine angefangenen Bücher und Podcasts aus jeder Bibliothek in einer Ansicht. Wenn deaktiviert, werden nur Inhalte aus der aktuell ausgewählten Bibliothek angezeigt.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing-Seite zeigt Inhalte aus allen Bibliotheken';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing-Seite zeigt Inhalte aus allen Bibliotheken';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing-Seite zeigt nur die aktuelle Bibliothek';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing-Seite zeigt nur die aktuelle Bibliothek';
 
   @override
   String get queueMode => 'Warteschlangenmodus';
@@ -1069,13 +1109,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get queueModeInfoOff => 'Aus';
 
   @override
-  String get queueModeInfoOffDesc => 'Die Wiedergabe stoppt, wenn das aktuelle Buch oder die Episode endet.';
+  String get queueModeInfoOffDesc =>
+      'Die Wiedergabe stoppt, wenn das aktuelle Buch oder die Episode endet.';
 
   @override
   String get queueModeInfoManual => 'Manuelle Warteschlange';
 
   @override
-  String get queueModeInfoManualDesc => 'Deine Absorbing-Karten funktionieren wie eine Playlist. Wenn eine endet, läuft die nächste noch nicht beendete Karte automatisch weiter. Füge Inhalte über den Button \"Zu Absorbing hinzufügen\" bei einem Buch oder einer Episode hinzu und sortiere sie auf dem Absorbing-Bildschirm um.';
+  String get queueModeInfoManualDesc =>
+      'Deine Absorbing-Karten funktionieren wie eine Playlist. Wenn eine endet, läuft die nächste noch nicht beendete Karte automatisch weiter. Füge Inhalte über den Button \"Zu Absorbing hinzufügen\" bei einem Buch oder einer Episode hinzu und sortiere sie auf dem Absorbing-Bildschirm um.';
 
   @override
   String get queueModeOff => 'Aus';
@@ -1093,7 +1135,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1150,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Beenden';
@@ -1162,7 +1206,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get defaultSpeed => 'Standardgeschwindigkeit';
 
   @override
-  String get defaultSpeedSubtitle => 'Neue Bücher starten mit dieser Geschwindigkeit - jedes Buch merkt sich seine eigene';
+  String get defaultSpeedSubtitle =>
+      'Neue Bücher starten mit dieser Geschwindigkeit - jedes Buch merkt sich seine eigene';
 
   @override
   String get skipBack => 'Zurückspulen';
@@ -1171,37 +1216,46 @@ class AppLocalizationsDe extends AppLocalizations {
   String get skipForward => 'Vorspulen';
 
   @override
-  String get chapterProgressInNotification => 'Kapitelfortschritt in der Benachrichtigung';
+  String get chapterProgressInNotification =>
+      'Kapitelfortschritt in der Benachrichtigung';
 
   @override
-  String get chapterProgressOnSubtitle => 'An - Sperrbildschirm zeigt Kapitelfortschritt';
+  String get chapterProgressOnSubtitle =>
+      'An - Sperrbildschirm zeigt Kapitelfortschritt';
 
   @override
-  String get chapterProgressOffSubtitle => 'Aus - Sperrbildschirm zeigt Fortschritt des gesamten Buchs';
+  String get chapterProgressOffSubtitle =>
+      'Aus - Sperrbildschirm zeigt Fortschritt des gesamten Buchs';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-Zurückspulen beim Fortsetzen';
@@ -1227,7 +1281,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rewindAlwaysLabel => 'Immer';
 
   @override
-  String get rewindAlwaysDescription => 'Spult jedes Mal beim Fortsetzen zurück, auch nach kurzen Unterbrechungen';
+  String get rewindAlwaysDescription =>
+      'Spult jedes Mal beim Fortsetzen zurück, auch nach kurzen Unterbrechungen';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1293,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterBarrier => 'Kapitelgrenze';
 
   @override
-  String get chapterBarrierSubtitle => 'Nicht über den Anfang des aktuellen Kapitels hinaus zurückspulen';
+  String get chapterBarrierSubtitle =>
+      'Nicht über den Anfang des aktuellen Kapitels hinaus zurückspulen';
 
   @override
   String get rewindInstant => 'Sofort';
@@ -1307,19 +1363,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get resetTimerOnPause => 'Timer bei Pause zurücksetzen';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer startet bei Fortsetzung von der vollen Dauer neu';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer startet bei Fortsetzung von der vollen Dauer neu';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer läuft dort weiter, wo er aufgehört hat';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer läuft dort weiter, wo er aufgehört hat';
 
   @override
   String get fadeVolumeBeforeSleep => 'Lautstärke vor dem Sleep ausblenden';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Senkt die Lautstärke in den letzten 30 Sekunden allmählich ab';
+  String get fadeVolumeOnSubtitle =>
+      'Senkt die Lautstärke in den letzten 30 Sekunden allmählich ab';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Wiedergabe stoppt sofort, wenn der Timer endet';
+  String get fadeVolumeOffSubtitle =>
+      'Wiedergabe stoppt sofort, wenn der Timer endet';
 
   @override
   String get autoSleepTimer => 'Automatischer Sleep-Timer';
@@ -1330,7 +1390,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Sleep-Timer in einem Zeitfenster automatisch starten';
+  String get autoSleepTimerOffSubtitle =>
+      'Sleep-Timer in einem Zeitfenster automatisch starten';
 
   @override
   String get windowStart => 'Fensterbeginn';
@@ -1375,10 +1436,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadOverWifiOnly => 'Nur über WLAN herunterladen';
 
   @override
-  String get downloadOverWifiOnSubtitle => 'An - mobile Daten für Downloads blockiert';
+  String get downloadOverWifiOnSubtitle =>
+      'An - mobile Daten für Downloads blockiert';
 
   @override
-  String get downloadOverWifiOffSubtitle => 'Aus - Downloads über jede Verbindung';
+  String get downloadOverWifiOffSubtitle =>
+      'Aus - Downloads über jede Verbindung';
 
   @override
   String get autoDownloadOnWifi => 'Auto-Download im WLAN';
@@ -1387,10 +1450,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download im WLAN';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'Wenn du ein Buch über WLAN streamst, wird das vollständige Buch automatisch im Hintergrund heruntergeladen. So hast du es offline verfügbar, ohne den Download manuell starten zu müssen.';
+  String get autoDownloadOnWifiInfoContent =>
+      'Wenn du ein Buch über WLAN streamst, wird das vollständige Buch automatisch im Hintergrund heruntergeladen. So hast du es offline verfügbar, ohne den Download manuell starten zu müssen.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Bücher werden im Hintergrund heruntergeladen, wenn du im WLAN streamst';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Bücher werden im Hintergrund heruntergeladen, wenn du im WLAN streamst';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Aus';
@@ -1402,7 +1467,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoDownload => 'Auto-Download';
 
   @override
-  String get autoDownloadSubtitle => 'Pro Serie oder Podcast über deren Detailseiten aktivieren';
+  String get autoDownloadSubtitle =>
+      'Pro Serie oder Podcast über deren Detailseiten aktivieren';
 
   @override
   String get keepNext => 'Nächste behalten';
@@ -1411,7 +1477,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get keepNextInfoTitle => 'Nächste behalten';
 
   @override
-  String get keepNextInfoContent => 'Die Anzahl der Elemente, die heruntergeladen bleiben sollen, einschließlich des Elements, das du gerade hörst. Beispiel: \"Nächste 3 behalten\" bedeutet, das aktuelle Buch plus die nächsten 2 in der Serie oder im Podcast bleiben heruntergeladen.';
+  String get keepNextInfoContent =>
+      'Die Anzahl der Elemente, die heruntergeladen bleiben sollen, einschließlich des Elements, das du gerade hörst. Beispiel: \"Nächste 3 behalten\" bedeutet, das aktuelle Buch plus die nächsten 2 in der Serie oder im Podcast bleiben heruntergeladen.';
 
   @override
   String get deleteAbsorbedDownloads => 'Absorbed Downloads löschen';
@@ -1420,13 +1487,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Absorbed Downloads löschen';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'Wenn aktiviert, werden heruntergeladene Bücher oder Episoden automatisch von deinem Gerät gelöscht, nachdem du sie zu Ende gehört hast. Das hilft, Speicherplatz freizugeben, während du dich durch deine Bibliothek arbeitest.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'Wenn aktiviert, werden heruntergeladene Bücher oder Episoden automatisch von deinem Gerät gelöscht, nachdem du sie zu Ende gehört hast. Das hilft, Speicherplatz freizugeben, während du dich durch deine Bibliothek arbeitest.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Beendete Elemente werden entfernt, um Platz zu sparen';
+  String get deleteAbsorbedOnSubtitle =>
+      'Beendete Elemente werden entfernt, um Platz zu sparen';
 
   @override
-  String get deleteAbsorbedOffSubtitle => 'Aus - beendete Downloads werden behalten';
+  String get deleteAbsorbedOffSubtitle =>
+      'Aus - beendete Downloads werden behalten';
 
   @override
   String get downloadLocation => 'Download-Speicherort';
@@ -1454,13 +1524,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming-Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Cached gestreamtes Audio auf der Festplatte, damit es nicht erneut heruntergeladen werden muss, wenn du zurückspulst oder Abschnitte erneut hörst. Der Cache wird automatisch verwaltet - älteste Dateien werden entfernt, wenn die Größenbegrenzung erreicht ist. Das ist getrennt von vollständig heruntergeladenen Büchern.';
+  String get streamingCacheInfoContent =>
+      'Cached gestreamtes Audio auf der Festplatte, damit es nicht erneut heruntergeladen werden muss, wenn du zurückspulst oder Abschnitte erneut hörst. Der Cache wird automatisch verwaltet - älteste Dateien werden entfernt, wenn die Größenbegrenzung erreicht ist. Das ist getrennt von vollständig heruntergeladenen Büchern.';
 
   @override
   String get streamingCacheOff => 'Aus';
 
   @override
-  String get streamingCacheOffSubtitle => 'Aus - Audio wird ohne Caching gestreamt';
+  String get streamingCacheOffSubtitle =>
+      'Aus - Audio wird ohne Caching gestreamt';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1480,16 +1552,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get hideEbookOnlyTitles => 'Nur-eBook-Titel ausblenden';
 
   @override
-  String get hideEbookOnlyOnSubtitle => 'Bücher ohne Audiodateien werden ausgeblendet';
+  String get hideEbookOnlyOnSubtitle =>
+      'Bücher ohne Audiodateien werden ausgeblendet';
 
   @override
-  String get hideEbookOnlyOffSubtitle => 'Aus - alle Bibliothekselemente werden angezeigt';
+  String get hideEbookOnlyOffSubtitle =>
+      'Aus - alle Bibliothekselemente werden angezeigt';
 
   @override
   String get showGoodreadsButton => 'Goodreads-Button anzeigen';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Buchdetails zeigen einen Link zu Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Buchdetails zeigen einen Link zu Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Aus - Goodreads-Button ausgeblendet';
@@ -1501,19 +1576,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get notifications => 'Benachrichtigungen';
 
   @override
-  String get notificationsSubtitle => 'Für Download-Fortschritt und Wiedergabesteuerung';
+  String get notificationsSubtitle =>
+      'Für Download-Fortschritt und Wiedergabesteuerung';
 
   @override
-  String get notificationsAlreadyEnabled => 'Benachrichtigungen sind bereits aktiviert';
+  String get notificationsAlreadyEnabled =>
+      'Benachrichtigungen sind bereits aktiviert';
 
   @override
   String get unrestrictedBattery => 'Uneingeschränkte Akkunutzung';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Verhindert, dass Android die Hintergrundwiedergabe beendet';
+  String get unrestrictedBatterySubtitle =>
+      'Verhindert, dass Android die Hintergrundwiedergabe beendet';
 
   @override
-  String get batteryAlreadyUnrestricted => 'Akkunutzung ist bereits uneingeschränkt';
+  String get batteryAlreadyUnrestricted =>
+      'Akkunutzung ist bereits uneingeschränkt';
 
   @override
   String get sectionIssuesAndSupport => 'Probleme & Support';
@@ -1540,16 +1619,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enableLogging => 'Logging aktivieren';
 
   @override
-  String get enableLoggingOnSubtitle => 'An - Logs werden in Datei gespeichert (Neustart nötig)';
+  String get enableLoggingOnSubtitle =>
+      'An - Logs werden in Datei gespeichert (Neustart nötig)';
 
   @override
   String get enableLoggingOffSubtitle => 'Aus - keine Logs werden erfasst';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging aktiviert - App neu starten, um Aufzeichnung zu beginnen';
+  String get loggingEnabledSnackbar =>
+      'Logging aktiviert - App neu starten, um Aufzeichnung zu beginnen';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging deaktiviert - App neu starten, um Aufzeichnung zu beenden';
+  String get loggingDisabledSnackbar =>
+      'Logging deaktiviert - App neu starten, um Aufzeichnung zu beenden';
 
   @override
   String get sendLogs => 'Logs senden';
@@ -1578,16 +1660,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get localServerInfoTitle => 'Lokaler Server';
 
   @override
-  String get localServerInfoContent => 'Wenn du deinen Audiobookshelf-Server zu Hause betreibst, kannst du hier eine lokale/LAN-URL festlegen. Absorb wechselt automatisch zur schnelleren lokalen Verbindung, wenn erkannt wird, dass du in deinem Heimnetzwerk bist, und greift unterwegs auf deine Remote-URL zurück.';
+  String get localServerInfoContent =>
+      'Wenn du deinen Audiobookshelf-Server zu Hause betreibst, kannst du hier eine lokale/LAN-URL festlegen. Absorb wechselt automatisch zur schnelleren lokalen Verbindung, wenn erkannt wird, dass du in deinem Heimnetzwerk bist, und greift unterwegs auf deine Remote-URL zurück.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Verbunden über lokalen Server';
 
   @override
-  String get localServerOnRemoteSubtitle => 'Aktiviert - Remote-Server wird verwendet';
+  String get localServerOnRemoteSubtitle =>
+      'Aktiviert - Remote-Server wird verwendet';
 
   @override
-  String get localServerOffSubtitle => 'Auto-Wechsel zu LAN-Server in deinem Heim-WLAN';
+  String get localServerOffSubtitle =>
+      'Auto-Wechsel zu LAN-Server in deinem Heim-WLAN';
 
   @override
   String get localServerUrlLabel => 'URL des lokalen Servers';
@@ -1596,7 +1681,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'URL des lokalen Servers gesetzt - verbindet sich automatisch in deinem Heimnetzwerk';
+  String get localServerUrlSetSnackbar =>
+      'URL des lokalen Servers gesetzt - verbindet sich automatisch in deinem Heimnetzwerk';
 
   @override
   String get disableAudioFocus => 'Audiofokus deaktivieren';
@@ -1605,19 +1691,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audiofokus';
 
   @override
-  String get disableAudioFocusInfoContent => 'Standardmäßig gibt Android jeweils einer App den Audio-\"Fokus\" - wenn Absorb spielt, pausiert anderes Audio (Musik, Videos). Wenn du den Audiofokus deaktivierst, kann Absorb neben anderen Apps wiedergegeben werden. Telefonate pausieren die Wiedergabe unabhängig von dieser Einstellung trotzdem.';
+  String get disableAudioFocusInfoContent =>
+      'Standardmäßig gibt Android jeweils einer App den Audio-\"Fokus\" - wenn Absorb spielt, pausiert anderes Audio (Musik, Videos). Wenn du den Audiofokus deaktivierst, kann Absorb neben anderen Apps wiedergegeben werden. Telefonate pausieren die Wiedergabe unabhängig von dieser Einstellung trotzdem.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'An - spielt neben anderem Audio (pausiert weiterhin bei Anrufen)';
+  String get disableAudioFocusOnSubtitle =>
+      'An - spielt neben anderem Audio (pausiert weiterhin bei Anrufen)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Aus - anderes Audio pausiert, wenn Absorb spielt';
+  String get disableAudioFocusOffSubtitle =>
+      'Aus - anderes Audio pausiert, wenn Absorb spielt';
 
   @override
   String get restartRequired => 'Neustart erforderlich';
 
   @override
-  String get restartRequiredContent => 'Die Änderung des Audiofokus erfordert einen vollständigen Neustart. App jetzt schließen?';
+  String get restartRequiredContent =>
+      'Die Änderung des Audiofokus erfordert einen vollständigen Neustart. App jetzt schließen?';
 
   @override
   String get closeApp => 'App schließen';
@@ -1629,13 +1719,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Selbstsignierte Zertifikate';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Aktiviere dies, wenn dein Audiobookshelf-Server ein selbstsigniertes Zertifikat oder eine eigene Root-CA verwendet. Wenn aktiviert, überspringt Absorb die TLS-Zertifikatsprüfung für alle Verbindungen. Aktiviere dies nur, wenn du deinem Netzwerk vertraust.';
+  String get trustAllCertificatesInfoContent =>
+      'Aktiviere dies, wenn dein Audiobookshelf-Server ein selbstsigniertes Zertifikat oder eine eigene Root-CA verwendet. Wenn aktiviert, überspringt Absorb die TLS-Zertifikatsprüfung für alle Verbindungen. Aktiviere dies nur, wenn du deinem Netzwerk vertraust.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'An - alle Zertifikate werden akzeptiert';
+  String get trustAllCertificatesOnSubtitle =>
+      'An - alle Zertifikate werden akzeptiert';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Aus - nur vertrauenswürdige Zertifikate akzeptiert';
+  String get trustAllCertificatesOffSubtitle =>
+      'Aus - nur vertrauenswürdige Zertifikate akzeptiert';
 
   @override
   String get supportTheDev => 'Den Entwickler unterstützen';
@@ -1657,7 +1750,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backupAndRestore => 'Sichern & Wiederherstellen';
 
   @override
-  String get backupAndRestoreSubtitle => 'Alle Einstellungen in einer Datei speichern oder wiederherstellen';
+  String get backupAndRestoreSubtitle =>
+      'Alle Einstellungen in einer Datei speichern oder wiederherstellen';
 
   @override
   String get backUp => 'Sichern';
@@ -1684,7 +1778,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get includeLoginInfoTitle => 'Login-Daten einschließen?';
 
   @override
-  String get includeLoginInfoContent => 'Möchtest du die Login-Daten aller deiner gespeicherten Konten in die Sicherung einschließen?\n\nDas erleichtert die Wiederherstellung auf einem neuen Gerät, aber die Datei enthält dann deine Auth-Tokens.';
+  String get includeLoginInfoContent =>
+      'Möchtest du die Login-Daten aller deiner gespeicherten Konten in die Sicherung einschließen?\n\nDas erleichtert die Wiederherstellung auf einem neuen Gerät, aber die Datei enthält dann deine Auth-Tokens.';
 
   @override
   String get noSettingsOnly => 'Nein, nur Einstellungen';
@@ -1696,7 +1791,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backupSavedWithAccounts => 'Sicherung gespeichert (mit Konten)';
 
   @override
-  String get backupSavedSettingsOnly => 'Sicherung gespeichert (nur Einstellungen)';
+  String get backupSavedSettingsOnly =>
+      'Sicherung gespeichert (nur Einstellungen)';
 
   @override
   String backupFailed(String error) {
@@ -1707,7 +1803,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get restoreBackupTitle => 'Sicherung wiederherstellen?';
 
   @override
-  String get restoreBackupContent => 'Dadurch werden alle deine aktuellen Einstellungen durch die Werte aus der Sicherung ersetzt.';
+  String get restoreBackupContent =>
+      'Dadurch werden alle deine aktuellen Einstellungen durch die Werte aus der Sicherung ersetzt.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1731,7 +1828,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get invalidBackupFile => 'Ungültige Sicherungsdatei';
 
   @override
-  String get settingsRestoredSuccessfully => 'Einstellungen erfolgreich wiederhergestellt';
+  String get settingsRestoredSuccessfully =>
+      'Einstellungen erfolgreich wiederhergestellt';
 
   @override
   String restoreFailed(String error) {
@@ -1742,7 +1840,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get logOutTitle => 'Abmelden?';
 
   @override
-  String get logOutContent => 'Du wirst abgemeldet. Deine Downloads bleiben auf diesem Gerät.';
+  String get logOutContent =>
+      'Du wirst abgemeldet. Deine Downloads bleiben auf diesem Gerät.';
 
   @override
   String get signOut => 'Abmelden';
@@ -1793,13 +1892,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download-Speicherort';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Wähle, wo Hörbücher gespeichert werden';
+  String get downloadLocationSheetSubtitle =>
+      'Wähle, wo Hörbücher gespeichert werden';
 
   @override
   String get currentLocation => 'Aktueller Speicherort';
 
   @override
-  String get existingDownloadsWarning => 'Vorhandene Downloads bleiben an ihrem aktuellen Speicherort. Nur neue Downloads verwenden den neuen Pfad.';
+  String get existingDownloadsWarning =>
+      'Vorhandene Downloads bleiben an ihrem aktuellen Speicherort. Nur neue Downloads verwenden den neuen Pfad.';
 
   @override
   String get chooseFolder => 'Ordner wählen';
@@ -1808,16 +1909,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chooseDownloadFolder => 'Download-Ordner wählen';
 
   @override
-  String get storagePermissionDenied => 'Speicherberechtigung dauerhaft verweigert - aktiviere sie in den App-Einstellungen';
+  String get storagePermissionDenied =>
+      'Speicherberechtigung dauerhaft verweigert - aktiviere sie in den App-Einstellungen';
 
   @override
   String get openSettings => 'Einstellungen öffnen';
 
   @override
-  String get storagePermissionRequired => 'Speicherberechtigung ist für eigene Download-Speicherorte erforderlich';
+  String get storagePermissionRequired =>
+      'Speicherberechtigung ist für eigene Download-Speicherorte erforderlich';
 
   @override
-  String get cannotWriteToFolder => 'Kann nicht in diesen Ordner schreiben - wähle einen anderen Speicherort oder gewähre in den Systemeinstellungen Dateizugriff';
+  String get cannotWriteToFolder =>
+      'Kann nicht in diesen Ordner schreiben - wähle einen anderen Speicherort oder gewähre in den Systemeinstellungen Dateizugriff';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1939,10 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1889,7 +1995,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcasts => 'Podcasts';
 
   @override
-  String get adminPodcastsSubtitle => 'Sendungen suchen, hinzufügen & verwalten';
+  String get adminPodcastsSubtitle =>
+      'Sendungen suchen, hinzufügen & verwalten';
 
   @override
   String get adminScan => 'Scannen';
@@ -1938,7 +2045,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook-URL';
 
   @override
-  String get adminRmabUrlHelp => 'Füge deine URL mit Login-Token ein. Generiere eine in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Füge deine URL mit Login-Token ein. Generiere eine in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,13 +2064,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminRmabReload => 'Neu laden';
 
   @override
-  String get adminRmabLoadFailed => 'ReadMeABook konnte nicht geladen werden. Prüfe deine URL.';
+  String get adminRmabLoadFailed =>
+      'ReadMeABook konnte nicht geladen werden. Prüfe deine URL.';
 
   @override
   String get adminRmabConnected => 'Verbunden';
 
   @override
-  String get adminRmabAskAdmin => 'Hol dir eine Login-URL von deinem Server-Admin';
+  String get adminRmabAskAdmin =>
+      'Hol dir eine Login-URL von deinem Server-Admin';
 
   @override
   String adminRmabApprovalsPending(int count) {
@@ -1976,19 +2086,23 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Hol dir eine Login-URL von deinem Server-Admin. Diese wird in RMAB > Admin > Users generiert.';
+  String get adminRmabUrlHelpUser =>
+      'Hol dir eine Login-URL von deinem Server-Admin. Diese wird in RMAB > Admin > Users generiert.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook ist ein selbst gehosteter Dienst zum Anfordern und Herunterladen von Hörbüchern. Es muss von deinem Server-Admin installiert und eingerichtet werden.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook ist ein selbst gehosteter Dienst zum Anfordern und Herunterladen von Hörbüchern. Es muss von deinem Server-Admin installiert und eingerichtet werden.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2126,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Verbinden';
@@ -2038,13 +2153,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token vom Server abgelehnt';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
 
   @override
-  String get rmabConfigErrorGeneric => 'Verbindung konnte nicht hergestellt werden';
+  String get rmabConfigErrorGeneric =>
+      'Verbindung konnte nicht hergestellt werden';
 
   @override
   String get rmabConfigSavedSnackbar => 'ReadMeABook connected';
@@ -2079,7 +2196,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Bereits in deiner Bibliothek';
@@ -2106,7 +2224,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2234,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'Meine Anfragen';
@@ -2142,13 +2262,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2487,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'Info';
@@ -2397,43 +2520,51 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get markAsFullyAbsorbedQuestion => 'Als vollständig Absorbed markieren?';
+  String get markAsFullyAbsorbedQuestion =>
+      'Als vollständig Absorbed markieren?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'Dadurch wird dein Fortschritt auf 100% gesetzt und die Wiedergabe gestoppt, falls dieses Buch gerade läuft.';
+  String get markAsFullyAbsorbedContent =>
+      'Dadurch wird dein Fortschritt auf 100% gesetzt und die Wiedergabe gestoppt, falls dieses Buch gerade läuft.';
 
   @override
   String get markedAsFinishedNiceWork => 'Als beendet markiert - gut gemacht!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Aktualisieren fehlgeschlagen - prüfe deine Verbindung';
+  String get failedToUpdateCheckConnection =>
+      'Aktualisieren fehlgeschlagen - prüfe deine Verbindung';
 
   @override
   String get markAsNotFinishedQuestion => 'Als nicht beendet markieren?';
 
   @override
-  String get markAsNotFinishedContent => 'Dadurch wird der Beendet-Status entfernt, deine aktuelle Position bleibt aber erhalten.';
+  String get markAsNotFinishedContent =>
+      'Dadurch wird der Beendet-Status entfernt, deine aktuelle Position bleibt aber erhalten.';
 
   @override
   String get unmark => 'Markierung entfernen';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Als nicht beendet markiert - weiter geht\'s!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Als nicht beendet markiert - weiter geht\'s!';
 
   @override
   String get resetProgressQuestion => 'Fortschritt zurücksetzen?';
 
   @override
-  String get resetProgressContent => 'Dadurch wird der gesamte Fortschritt für dieses Buch gelöscht und es auf den Anfang zurückgesetzt. Das kann nicht rückgängig gemacht werden.';
+  String get resetProgressContent =>
+      'Dadurch wird der gesamte Fortschritt für dieses Buch gelöscht und es auf den Anfang zurückgesetzt. Das kann nicht rückgängig gemacht werden.';
 
   @override
-  String get progressResetFreshStart => 'Fortschritt zurückgesetzt - frischer Start!';
+  String get progressResetFreshStart =>
+      'Fortschritt zurückgesetzt - frischer Start!';
 
   @override
   String get clearLocalMetadataQuestion => 'Lokale Metadaten löschen?';
 
   @override
-  String get clearLocalMetadataContent => 'Dadurch werden die lokal gespeicherten Metadaten entfernt und auf das zurückgesetzt, was der Server hat.';
+  String get clearLocalMetadataContent =>
+      'Dadurch werden die lokal gespeicherten Metadaten entfernt und auf das zurückgesetzt, was der Server hat.';
 
   @override
   String get localMetadataCleared => 'Lokale Metadaten gelöscht';
@@ -2462,7 +2593,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noBookmarksYet => 'Noch keine Lesezeichen';
 
   @override
-  String get longPressBookmarkHint => 'Lange auf den Lesezeichen-Button drücken zum schnellen Speichern';
+  String get longPressBookmarkHint =>
+      'Lange auf den Lesezeichen-Button drücken zum schnellen Speichern';
 
   @override
   String get addBookmark => 'Lesezeichen hinzufügen';
@@ -2495,7 +2627,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get clearHistoryTooltip => 'Verlauf löschen';
 
   @override
-  String get tapEventToJump => 'Tippe auf ein Ereignis, um zu dieser Position zu springen';
+  String get tapEventToJump =>
+      'Tippe auf ein Ereignis, um zu dieser Position zu springen';
 
   @override
   String get noHistoryYet => 'Noch kein Verlauf';
@@ -2545,7 +2678,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoDownloadThisSeries => 'Diese Serie automatisch herunterladen?';
 
   @override
-  String get autoDownloadSeriesContent => 'Lädt die nächsten Bücher beim Hören automatisch herunter.';
+  String get autoDownloadSeriesContent =>
+      'Lädt die nächsten Bücher beim Hören automatisch herunter.';
 
   @override
   String get standalone => 'Eigenständig';
@@ -2580,10 +2714,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get selectAll => 'Alle auswählen';
 
   @override
-  String get autoDownloadThisPodcast => 'Diesen Podcast automatisch herunterladen?';
+  String get autoDownloadThisPodcast =>
+      'Diesen Podcast automatisch herunterladen?';
 
   @override
-  String get autoDownloadPodcastContent => 'Lädt die nächsten Episoden beim Hören automatisch herunter.';
+  String get autoDownloadPodcastContent =>
+      'Lädt die nächsten Episoden beim Hören automatisch herunter.';
 
   @override
   String get download => 'Herunterladen';
@@ -2610,7 +2746,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authorOptionalLabel => 'Autor (optional)';
 
   @override
-  String get noResultsFound => 'Keine Ergebnisse gefunden.\nPasse deine Suche oder den Anbieter an.';
+  String get noResultsFound =>
+      'Keine Ergebnisse gefunden.\nPasse deine Suche oder den Anbieter an.';
 
   @override
   String get searchForMetadataAbove => 'Oben nach Metadaten suchen';
@@ -2622,7 +2759,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get metadataUpdated => 'Metadaten aktualisiert';
 
   @override
-  String get failedToUpdateMetadata => 'Metadaten konnten nicht aktualisiert werden';
+  String get failedToUpdateMetadata =>
+      'Metadaten konnten nicht aktualisiert werden';
 
   @override
   String get subtitleLabel => 'Untertitel';
@@ -2760,13 +2898,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteCollection => 'Sammlung löschen';
 
   @override
-  String get deleteCollectionContent => 'Möchtest du diese Sammlung wirklich löschen?';
+  String get deleteCollectionContent =>
+      'Möchtest du diese Sammlung wirklich löschen?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist nicht gefunden';
@@ -2775,7 +2915,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deletePlaylist => 'Playlist löschen';
 
   @override
-  String get deletePlaylistContent => 'Möchtest du diese Playlist wirklich löschen?';
+  String get deletePlaylistContent =>
+      'Möchtest du diese Playlist wirklich löschen?';
 
   @override
   String get newPlaylist => 'Neue Playlist';
@@ -2828,7 +2969,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'Wir verwenden \"Absorb\" anstelle von \"abspielen\" und \"hören\".';
+  String get welcomeAbsorbingIntro =>
+      'Wir verwenden \"Absorb\" anstelle von \"abspielen\" und \"hören\".';
 
   @override
   String get welcomeAbsorbingTabBullet => 'Absorbing-Tab - was du gerade hörst';
@@ -2843,13 +2985,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Zurechtfinden';
 
   @override
-  String get welcomeGettingAroundBody => 'Tippe auf ein Cover, um die Details zu öffnen. Weiterhören-Karten sind anders - tippe für sofortige Wiedergabe, lange drücken für Details.';
+  String get welcomeGettingAroundBody =>
+      'Tippe auf ein Cover, um die Details zu öffnen. Weiterhören-Karten sind anders - tippe für sofortige Wiedergabe, lange drücken für Details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Mach es zu deinem';
 
   @override
-  String get welcomeMakeItYoursBody => 'Stöbere in den Einstellungen und passe Absorb deinem Geschmack an. Der Bereich Tipps & versteckte Funktionen lohnt sich auf jeden Fall.';
+  String get welcomeMakeItYoursBody =>
+      'Stöbere in den Einstellungen und passe Absorb deinem Geschmack an. Der Bereich Tipps & versteckte Funktionen lohnt sich auf jeden Fall.';
 
   @override
   String get getStarted => 'Los geht\'s';
@@ -2900,7 +3044,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get serverAdmin => 'Server-Admin';
 
   @override
-  String get serverAdminSubtitle => 'Benutzer, Bibliotheken & Server-Einstellungen verwalten';
+  String get serverAdminSubtitle =>
+      'Benutzer, Bibliotheken & Server-Einstellungen verwalten';
 
   @override
   String get justNow => 'Gerade eben';
@@ -2936,10 +3081,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get coverPlayPause => 'Cover Play/Pause';
 
   @override
-  String get coverPlayPauseOnSubtitle => 'An - tippe auf das Cover für Play/Pause';
+  String get coverPlayPauseOnSubtitle =>
+      'An - tippe auf das Cover für Play/Pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Aus - eigener Play/Pause-Button in den Steuerelementen';
+  String get coverPlayPauseOffSubtitle =>
+      'Aus - eigener Play/Pause-Button in den Steuerelementen';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3098,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Wiedergabe stoppt, manuelle Warteschlange oder Auto-Absorb des nächsten Elements';
+  String get queueModeMergedSubtitle =>
+      'Wiedergabe stoppt, manuelle Warteschlange oder Auto-Absorb des nächsten Elements';
 
   @override
   String get queueModeSeriesLabel => 'Serie';
@@ -2963,13 +3111,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get queueModeInfoSeries => 'Serie';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Spielt automatisch das nächste Buch einer Serie oder die nächste Episode einer Podcast-Sendung ab.';
+  String get queueModeInfoSeriesDesc =>
+      'Spielt automatisch das nächste Buch einer Serie oder die nächste Episode einer Podcast-Sendung ab.';
 
   @override
   String get resetButtonGridQuestion => 'Button-Raster zurücksetzen?';
 
   @override
-  String get resetButtonGridContent => 'Dies stellt das Standard-Button-Layout, die Reihenfolge und die Schaltereinstellungen wieder her.';
+  String get resetButtonGridContent =>
+      'Dies stellt das Standard-Button-Layout, die Reihenfolge und die Schaltereinstellungen wieder her.';
 
   @override
   String get reset => 'Zurücksetzen';
@@ -2987,13 +3137,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Kapitelgrenze';
 
   @override
-  String get chapterBarrierInfoContent => 'Beim Zurückspulen springt die Wiedergabe an den Anfang des aktuellen Kapitels, statt ins vorherige zu wechseln.\n\nTippe innerhalb von 2 Sekunden zweimal auf den Zurückspulen-Button, um die Grenze zu durchbrechen.';
+  String get chapterBarrierInfoContent =>
+      'Beim Zurückspulen springt die Wiedergabe an den Anfang des aktuellen Kapitels, statt ins vorherige zu wechseln.\n\nTippe innerhalb von 2 Sekunden zweimal auf den Zurückspulen-Button, um die Grenze zu durchbrechen.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'An - Zurückspulen springt zum Kapitelanfang';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'An - Zurückspulen springt zum Kapitelanfang';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Aus - Zurückspulen überschreitet Kapitelgrenzen';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Aus - Zurückspulen überschreitet Kapitelgrenzen';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3157,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rewindOnSessionStart => 'Zurückspulen bei Sitzungsstart';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Das normale Auto-Zurückspulen wird ausgelöst, wenn du innerhalb einer aktiven Sitzung aus einer Pause fortsetzt. Diese Einstellung fügt ein Zurückspulen beim Start einer komplett neuen Sitzung hinzu - zum Beispiel nach dem Schließen der App, gestoppter Wiedergabe oder beim frischen Öffnen der App.\n\nWenn aktiviert, springt die Wiedergabe zu Beginn jeder neuen Sitzung um den vollen maximalen Zurückspul-Wert zurück, damit du noch einmal hörst, wo du aufgehört hast.';
+  String get rewindOnSessionStartInfoContent =>
+      'Das normale Auto-Zurückspulen wird ausgelöst, wenn du innerhalb einer aktiven Sitzung aus einer Pause fortsetzt. Diese Einstellung fügt ein Zurückspulen beim Start einer komplett neuen Sitzung hinzu - zum Beispiel nach dem Schließen der App, gestoppter Wiedergabe oder beim frischen Öffnen der App.\n\nWenn aktiviert, springt die Wiedergabe zu Beginn jeder neuen Sitzung um den vollen maximalen Zurückspul-Wert zurück, damit du noch einmal hörst, wo du aufgehört hast.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3212,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chimeBeforeSleep => 'Glocke vor Sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Spielt eine sanfte Glocke, bevor der Timer endet';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Spielt eine sanfte Glocke, bevor der Timer endet';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'Keine Tonwarnung vor Sleep';
@@ -3077,7 +3232,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start - $end · $duration';
   }
 
@@ -3094,10 +3250,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showExplicitBadge => 'Explicit-Abzeichen anzeigen';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit-Inhalte zeigen ein \"E\"-Abzeichen';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit-Inhalte zeigen ein \"E\"-Abzeichen';
 
   @override
-  String get showExplicitBadgeOffSubtitle => 'Aus - Explicit-Abzeichen ausgeblendet';
+  String get showExplicitBadgeOffSubtitle =>
+      'Aus - Explicit-Abzeichen ausgeblendet';
 
   @override
   String get libraryFallback => 'Bibliothek';
@@ -3106,13 +3264,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-Release-Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'Wenn aktiviert, informiert dich der Update-Checker auch über Alpha- und Pre-Release-Builds von GitHub. Diese können instabiler sein, enthalten aber die neuesten Funktionen und Korrekturen.';
+  String get preReleaseUpdatesInfoContent =>
+      'Wenn aktiviert, informiert dich der Update-Checker auch über Alpha- und Pre-Release-Builds von GitHub. Diese können instabiler sein, enthalten aber die neuesten Funktionen und Korrekturen.';
 
   @override
   String get includePreReleases => 'Pre-Releases einbeziehen';
 
   @override
-  String get includePreReleasesOnSubtitle => 'An - sucht nach Alpha- & Pre-Release-Builds';
+  String get includePreReleasesOnSubtitle =>
+      'An - sucht nach Alpha- & Pre-Release-Builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Aus - nur stabile Versionen';
@@ -3153,10 +3313,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get updateDownloading => 'Update wird heruntergeladen...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
-  String get updateOpeningInBrowser => 'Das In-App-Update ist fehlgeschlagen, Browser wird geöffnet';
+  String get updateOpeningInBrowser =>
+      'Das In-App-Update ist fehlgeschlagen, Browser wird geöffnet';
 
   @override
   String get sendToEreader => 'An E-Reader senden';
@@ -3223,7 +3385,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get smtpSaved => 'E-Mail-Einstellungen gespeichert';
 
   @override
-  String get smtpSaveFailed => 'Die E-Mail-Einstellungen konnten nicht gespeichert werden';
+  String get smtpSaveFailed =>
+      'Die E-Mail-Einstellungen konnten nicht gespeichert werden';
 
   @override
   String get smtpTestSent => 'Test-E-Mail gesendet';
@@ -3235,7 +3398,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ereaderDevicesTitle => 'E-Reader-Geräte';
 
   @override
-  String get ereaderDevicesEmpty => 'Noch keine Geräte. Füge unten eines hinzu.';
+  String get ereaderDevicesEmpty =>
+      'Noch keine Geräte. Füge unten eines hinzu.';
 
   @override
   String get addEreaderDevice => 'Gerät hinzufügen';
@@ -3276,7 +3440,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ereaderDevicesSaved => 'Geräte gespeichert';
 
   @override
-  String get ereaderDevicesSaveFailed => 'Geräte konnten nicht gespeichert werden';
+  String get ereaderDevicesSaveFailed =>
+      'Geräte konnten nicht gespeichert werden';
 
   @override
   String libraryCountOne(int count) {
@@ -3307,7 +3472,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Nach Position sortiert (umgekehrt)';
+  String get bookmarksSortedByPositionReversed =>
+      'Nach Position sortiert (umgekehrt)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3552,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Zurücksetzen wurde möglicherweise nicht synchronisiert - prüfe deinen Server';
+  String get resetMayNotHaveSynced =>
+      'Zurücksetzen wurde möglicherweise nicht synchronisiert - prüfe deinen Server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3561,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Der Server hat eine Fehlerseite statt der E-Book-Datei zurückgegeben';
+  String get serverReturnedErrorPage =>
+      'Der Server hat eine Fehlerseite statt der E-Book-Datei zurückgegeben';
 
   @override
   String ebookSaved(String filename) {
@@ -3527,7 +3695,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersEnterPassword => 'Passwort eingeben';
 
   @override
-  String get adminUsersLeaveBlankToKeep => 'Leer lassen, um aktuelles zu behalten';
+  String get adminUsersLeaveBlankToKeep =>
+      'Leer lassen, um aktuelles zu behalten';
 
   @override
   String get adminUsersAccountType => 'Kontotyp';
@@ -3548,7 +3717,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersAccountActive => 'Konto aktiv';
 
   @override
-  String get adminUsersAccountActiveSub => 'Deaktivierte Konten können sich nicht anmelden';
+  String get adminUsersAccountActiveSub =>
+      'Deaktivierte Konten können sich nicht anmelden';
 
   @override
   String get adminUsersLocked => 'Gesperrt';
@@ -3566,7 +3736,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersPermUpdate => 'Aktualisieren';
 
   @override
-  String get adminUsersPermUpdateSub => 'Metadaten und Bibliothekselemente bearbeiten';
+  String get adminUsersPermUpdateSub =>
+      'Metadaten und Bibliothekselemente bearbeiten';
 
   @override
   String get adminUsersPermDelete => 'Löschen';
@@ -3605,7 +3776,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersFailedCreate => 'Benutzer konnte nicht erstellt werden';
 
   @override
-  String get adminUsersFailedUpdate => 'Benutzer konnte nicht aktualisiert werden';
+  String get adminUsersFailedUpdate =>
+      'Benutzer konnte nicht aktualisiert werden';
 
   @override
   String get adminUsersThisUser => 'diesen Benutzer';
@@ -3694,10 +3866,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Auf neue Episoden prüfen';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'Dies prüft die RSS-Feeds aller Podcasts und lädt alle gefundenen neuen Episoden herunter (sofern Auto-Download aktiviert ist).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'Dies prüft die RSS-Feeds aller Podcasts und lädt alle gefundenen neuen Episoden herunter (sofern Auto-Download aktiviert ist).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'RSS-Feed durchsuchen und neue Episoden herunterladen';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'RSS-Feed durchsuchen und neue Episoden herunterladen';
 
   @override
   String get adminPodcastsCheck => 'Prüfen';
@@ -3709,7 +3883,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsCheckingForNewDots => 'Suche nach neuen Episoden...';
 
   @override
-  String get adminPodcastsFailedCheckEpisodes => 'Episoden konnten nicht geprüft werden';
+  String get adminPodcastsFailedCheckEpisodes =>
+      'Episoden konnten nicht geprüft werden';
 
   @override
   String get adminPodcastsCheckFeedsTooltip => 'Feeds auf neue Episoden prüfen';
@@ -3718,7 +3893,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsNoPodcastsYet => 'Noch keine Podcasts';
 
   @override
-  String get adminPodcastsTapPlusHint => 'Tippe auf +, um Sendungen zu suchen und hinzuzufügen';
+  String get adminPodcastsTapPlusHint =>
+      'Tippe auf +, um Sendungen zu suchen und hinzuzufügen';
 
   @override
   String adminPodcastsEpisodesCount(int count) {
@@ -3869,7 +4045,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedRemoveShow => 'Sendung konnte nicht entfernt werden';
+  String get adminPodcastsFailedRemoveShow =>
+      'Sendung konnte nicht entfernt werden';
 
   @override
   String get adminPodcastsRemoveShowTooltip => 'Sendung entfernen';
@@ -3927,7 +4104,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsBrowseFeedToDownload => 'Feed durchsuchen, um herunterzuladen';
+  String get adminPodcastsBrowseFeedToDownload =>
+      'Feed durchsuchen, um herunterzuladen';
 
   @override
   String get adminPodcastsDownloadingDots => 'Wird heruntergeladen...';
@@ -3967,7 +4145,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Suche nach neuen Episoden fehlgeschlagen';
+  String get adminPodcastsFailedToCheckNew =>
+      'Suche nach neuen Episoden fehlgeschlagen';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Prüfen & Herunterladen';
@@ -3976,19 +4155,24 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Podcast zuordnen';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'iTunes durchsuchen, um Cover und Metadaten zu aktualisieren';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'iTunes durchsuchen, um Cover und Metadaten zu aktualisieren';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Neue Episoden automatisch herunterladen';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Neue Episoden automatisch herunterladen';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server lädt neue Episoden automatisch herunter';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server lädt neue Episoden automatisch herunter';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'Neue Episoden werden nicht automatisch heruntergeladen';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'Neue Episoden werden nicht automatisch heruntergeladen';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Auto-Download-Einstellung konnte nicht aktualisiert werden';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Auto-Download-Einstellung konnte nicht aktualisiert werden';
 
   @override
   String get adminPodcastsCheckSchedule => 'Prüfplan';
@@ -4064,10 +4248,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsNoResults => 'Keine Ergebnisse';
 
   @override
-  String get adminPodcastsPodcastMatched => 'Podcast zugeordnet und aktualisiert';
+  String get adminPodcastsPodcastMatched =>
+      'Podcast zugeordnet und aktualisiert';
 
   @override
-  String get adminPodcastsFailedMatch => 'Podcast konnte nicht zugeordnet werden';
+  String get adminPodcastsFailedMatch =>
+      'Podcast konnte nicht zugeordnet werden';
 
   @override
   String get episodeListEpisodeFallback => 'Episode';
@@ -4098,7 +4284,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Neue Episoden abbestellen';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Neue Episoden abbestellen';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Neue Episoden abonnieren';
@@ -4107,7 +4294,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Diesen Podcast abonnieren?';
 
   @override
-  String get episodeListSubscribeContent => 'Neue Episoden werden automatisch heruntergeladen und zu deiner Absorbing-Warteschlange hinzugefügt, sobald sie auf dem Server erscheinen.';
+  String get episodeListSubscribeContent =>
+      'Neue Episoden werden automatisch heruntergeladen und zu deiner Absorbing-Warteschlange hinzugefügt, sobald sie auf dem Server erscheinen.';
 
   @override
   String get episodeListSubscribe => 'Abonnieren';
@@ -4119,10 +4307,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get episodeListHideFinishedEpisodes => 'Beendete Episoden ausblenden';
 
   @override
-  String get episodeListPlaysNewerToOlder => 'Spielt von neueren zu älteren Episoden';
+  String get episodeListPlaysNewerToOlder =>
+      'Spielt von neueren zu älteren Episoden';
 
   @override
-  String get episodeListPlaysOlderToNewer => 'Spielt von älteren zu neueren Episoden';
+  String get episodeListPlaysOlderToNewer =>
+      'Spielt von älteren zu neueren Episoden';
 
   @override
   String episodeListEpisodeCount(int count) {
@@ -4176,10 +4366,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Als beendet markiert - super!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'Dies setzt deinen Fortschritt für diese Episode auf 100 %.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'Dies setzt deinen Fortschritt für diese Episode auf 100 %.';
 
   @override
-  String get episodeDetailResetProgressContent => 'Dies löscht den gesamten Fortschritt für diese Episode und setzt sie auf den Anfang zurück. Das kann nicht rückgängig gemacht werden.';
+  String get episodeDetailResetProgressContent =>
+      'Dies löscht den gesamten Fortschritt für diese Episode und setzt sie auf den Anfang zurück. Das kann nicht rückgängig gemacht werden.';
 
   @override
   String get episodeDetailToday => 'Heute';
@@ -4224,7 +4416,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get editMetadataUpdatedFromMatch => 'Metadaten aus Zuordnung aktualisiert';
+  String get editMetadataUpdatedFromMatch =>
+      'Metadaten aus Zuordnung aktualisiert';
 
   @override
   String editMetadataConfirmMatch(String title) {
@@ -4240,18 +4433,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Fehlende Bücher finden';
 
   @override
-  String get seriesBooksFindMissingContent => 'Dies durchsucht Audible nach Büchern dieser Serie, die in deiner Bibliothek fehlen könnten.\n\nBücher werden zuerst über die ASIN abgeglichen (sofern dein Server ASINs für seine Bücher hat) und greifen dann auf den Titelabgleich zurück. Die Ergebnisse sind möglicherweise nicht ganz genau.';
+  String get seriesBooksFindMissingContent =>
+      'Dies durchsucht Audible nach Büchern dieser Serie, die in deiner Bibliothek fehlen könnten.\n\nBücher werden zuerst über die ASIN abgeglichen (sofern dein Server ASINs für seine Bücher hat) und greifen dann auf den Titelabgleich zurück. Die Ergebnisse sind möglicherweise nicht ganz genau.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Diese Serie konnte auf Audible nicht gefunden werden';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Diese Serie konnte auf Audible nicht gefunden werden';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Damit wird der Beendet-Status für alle $count Bücher dieser Serie zurückgesetzt.',
-      one: 'Damit wird der Beendet-Status für 1 Buch dieser Serie zurückgesetzt.',
+      other:
+          'Damit wird der Beendet-Status für alle $count Bücher dieser Serie zurückgesetzt.',
+      one:
+          'Damit wird der Beendet-Status für 1 Buch dieser Serie zurückgesetzt.',
     );
     return '$_temp0';
   }
@@ -4261,7 +4458,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Damit werden alle $count Bücher dieser Serie als beendet markiert.',
+      other:
+          'Damit werden alle $count Bücher dieser Serie als beendet markiert.',
       one: 'Damit wird 1 Buch dieser Serie als beendet markiert.',
     );
     return '$_temp0';
@@ -4379,10 +4577,12 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get statsScreenCouldNotLoadItem => 'Element konnte nicht geladen werden';
+  String get statsScreenCouldNotLoadItem =>
+      'Element konnte nicht geladen werden';
 
   @override
-  String get statsScreenCouldNotFindEpisode => 'Episode konnte nicht gefunden werden';
+  String get statsScreenCouldNotFindEpisode =>
+      'Episode konnte nicht gefunden werden';
 
   @override
   String statsScreenByAuthor(String author) {
@@ -4402,7 +4602,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4671,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$day. $month $year um $hour:$minute $ampm';
   }
 
@@ -4528,7 +4730,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get upcomingReleasesRescan => 'Erneut scannen';
 
   @override
-  String get upcomingReleasesRescanReleaseDate => 'Veröffentlichungstermin erneut scannen';
+  String get upcomingReleasesRescanReleaseDate =>
+      'Veröffentlichungstermin erneut scannen';
 
   @override
   String get upcomingReleasesRescanning => 'Wird erneut gescannt...';
@@ -4539,7 +4742,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoReleaseDateFound => 'Kein Veröffentlichungstermin gefunden';
+  String get upcomingReleasesNoReleaseDateFound =>
+      'Kein Veröffentlichungstermin gefunden';
 
   @override
   String get upcomingReleasesRescanFailed => 'Erneuter Scan fehlgeschlagen';
@@ -4583,7 +4787,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'Keine kommenden oder kürzlichen Veröffentlichungen gefunden';
+  String get upcomingReleasesNoneFound =>
+      'Keine kommenden oder kürzlichen Veröffentlichungen gefunden';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4677,7 +4882,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audibleSeriesNoBooksFound => 'Keine Bücher auf Audible gefunden';
 
   @override
-  String get audibleSeriesFailedToLoad => 'Serie konnte nicht von Audible geladen werden';
+  String get audibleSeriesFailedToLoad =>
+      'Serie konnte nicht von Audible geladen werden';
 
   @override
   String audibleSeriesSummary(int total, int missing) {
@@ -4685,7 +4891,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total auf Audible · $missing fehlen · $upcoming kommend';
   }
 
@@ -4711,7 +4918,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audibleSeriesCompleteSeries => 'Du hast die komplette Serie!';
 
   @override
-  String get audibleSeriesNoUpcoming => 'Keine kommenden Veröffentlichungen gefunden';
+  String get audibleSeriesNoUpcoming =>
+      'Keine kommenden Veröffentlichungen gefunden';
 
   @override
   String get audibleSeriesUpcomingBadge => 'KOMMEND';
@@ -4738,10 +4946,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audibleSeriesAlreadyInUpcoming => 'Already on the upcoming page';
 
   @override
-  String get audibleSeriesCouldNotOpenAudible => 'Audible konnte nicht geöffnet werden';
+  String get audibleSeriesCouldNotOpenAudible =>
+      'Audible konnte nicht geöffnet werden';
 
   @override
-  String get audibleSeriesCouldNotOpenCalendar => 'Kalender konnte nicht geöffnet werden';
+  String get audibleSeriesCouldNotOpenCalendar =>
+      'Kalender konnte nicht geöffnet werden';
 
   @override
   String audibleSeriesCalendarDescription(String seriesName) {
@@ -4779,7 +4989,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get metadataLookupOverrideLocalDisplay => 'Lokale Anzeige überschreiben';
+  String get metadataLookupOverrideLocalDisplay =>
+      'Lokale Anzeige überschreiben';
 
   @override
   String get equalizerPresetFlat => 'Flach';
@@ -4834,7 +5045,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Kommende Veröffentlichungen';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Audible nach neuen Veröffentlichungen in deinen Serien durchsuchen';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Audible nach neuen Veröffentlichungen in deinen Serien durchsuchen';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5157,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'Dieser Zeitpunkt ist bereits vorbei';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'Dieser Zeitpunkt ist bereits vorbei';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Timer starten';
@@ -5031,7 +5244,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Genre-Bereich hinzufügen';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Wähle ein Genre für deinen Startbildschirm';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Wähle ein Genre für deinen Startbildschirm';
 
   @override
   String get homeSectionDoneBadge => 'Fertig';
@@ -5040,121 +5254,143 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Schnelle Lesezeichen';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Halte den Lesezeichen-Button auf einer Karte gedrückt, um sofort ein Lesezeichen an der aktuellen Position zu setzen, ohne das Lesezeichen-Menü zu öffnen.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Halte den Lesezeichen-Button auf einer Karte gedrückt, um sofort ein Lesezeichen an der aktuellen Position zu setzen, ohne das Lesezeichen-Menü zu öffnen.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover zum Pausieren';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tippe auf das Cover einer Karte, um abzuspielen oder zu pausieren. Schalte das in den Einstellungen unter Absorbing-Karten um. Ein dezentes Pause-Symbol zeigt sich beim Abspielen, damit du weißt, dass es antippbar ist.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tippe auf das Cover einer Karte, um abzuspielen oder zu pausieren. Schalte das in den Einstellungen unter Absorbing-Karten um. Ein dezentes Pause-Symbol zeigt sich beim Abspielen, damit du weißt, dass es antippbar ist.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Vollbild-Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Wische auf einer Absorbing-Karte nach oben, um den Vollbild-Player zu öffnen. Wische nach unten, um ihn zu schließen.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Wische auf einer Absorbing-Karte nach oben, um den Vollbild-Player zu öffnen. Wische nach unten, um ihn zu schließen.';
 
   @override
-  String get tipsSheetQuickAddAbsorbingTitle => 'Schnell zu Absorbing hinzufügen';
+  String get tipsSheetQuickAddAbsorbingTitle =>
+      'Schnell zu Absorbing hinzufügen';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Wische in einem Listen-Sheet (Serie, Autor, Suchergebnisse) nach rechts auf einem Buch, um es sofort zur Absorbing-Warteschlange hinzuzufügen.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Wische in einem Listen-Sheet (Serie, Autor, Suchergebnisse) nach rechts auf einem Buch, um es sofort zur Absorbing-Warteschlange hinzuzufügen.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Schütteln verlängert Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'Wenn ein Sleep-Timer läuft und du dein Handy schüttelst, werden zusätzliche Minuten draufgepackt. Stelle die Menge in den Einstellungen unter Sleep-Timer ein.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'Wenn ein Sleep-Timer läuft und du dein Handy schüttelst, werden zusätzliche Minuten draufgepackt. Stelle die Menge in den Einstellungen unter Sleep-Timer ein.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Serien-Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tippe in den Buchdetails auf den Seriennamen, um alle Bücher der Serie in Lesereihenfolge zu sehen, mit Reihenfolge-Badges auf jedem Cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tippe in den Buchdetails auf den Seriennamen, um alle Bücher der Serie in Lesereihenfolge zu sehen, mit Reihenfolge-Badges auf jedem Cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Zwischen Büchern wischen';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Wische auf dem Absorbing-Bildschirm nach links und rechts, um zwischen deinen angefangenen Büchern zu wechseln. Im manuellen Warteschlangenmodus dienen die Karten als Warteschlange, sodass das nächste Buch automatisch startet, wenn das aktuelle endet.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Wische auf dem Absorbing-Bildschirm nach links und rechts, um zwischen deinen angefangenen Büchern zu wechseln. Im manuellen Warteschlangenmodus dienen die Karten als Warteschlange, sodass das nächste Buch automatisch startet, wenn das aktuelle endet.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tippen zum Spulen';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tippe irgendwo auf den Kapitel- oder Buchfortschrittsbalken, um direkt zu dieser Stelle zu springen. Du kannst die Balken auch ziehen, um feiner zu steuern.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tippe irgendwo auf den Kapitel- oder Buchfortschrittsbalken, um direkt zu dieser Stelle zu springen. Du kannst die Balken auch ziehen, um feiner zu steuern.';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeTitle => 'Geschwindigkeitsangepasste Zeit';
+  String get tipsSheetSpeedAdjustedTimeTitle =>
+      'Geschwindigkeitsangepasste Zeit';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Restzeit und Kapitelzeiten passen sich automatisch deiner Wiedergabegeschwindigkeit an. Hörst du mit 1,5x? Die angezeigte Zeit zeigt, wie lange es tatsächlich dauert.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Restzeit und Kapitelzeiten passen sich automatisch deiner Wiedergabegeschwindigkeit an. Hörst du mit 1,5x? Die angezeigte Zeit zeigt, wie lange es tatsächlich dauert.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Wiedergabe-Verlauf';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tippe auf einer Karte auf den Verlaufs-Button, um eine Zeitleiste mit jeder Wiedergabe, Pause, Sprung und Geschwindigkeitsänderung zu sehen. Tippe auf ein Ereignis, um zu dieser Stelle zurückzuspringen.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tippe auf einer Karte auf den Verlaufs-Button, um eine Zeitleiste mit jeder Wiedergabe, Pause, Sprung und Geschwindigkeitsänderung zu sehen. Tippe auf ein Ereignis, um zu dieser Stelle zurückzuspringen.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Zurückspulen';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'Wenn du nach einer Pause weiterhörst, spult Absorb automatisch ein paar Sekunden zurück, damit du den Anschluss nicht verlierst. Wie weit zurückgespult wird, hängt davon ab, wie lange du weg warst. In den Einstellungen anpassbar.';
+  String get tipsSheetAutoRewindDesc =>
+      'Wenn du nach einer Pause weiterhörst, spult Absorb automatisch ein paar Sekunden zurück, damit du den Anschluss nicht verlierst. Wie weit zurückgespult wird, hängt davon ab, wie lange du weg warst. In den Einstellungen anpassbar.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Serien-Warteschlangenmodus';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'Wenn du ein Buch beendest, das Teil einer Serie ist, kann Absorb automatisch das nächste Buch abspielen. Stelle den Warteschlangenmodus in den Einstellungen auf \"Serie\".';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'Wenn du ein Buch beendest, das Teil einer Serie ist, kann Absorb automatisch das nächste Buch abspielen. Stelle den Warteschlangenmodus in den Einstellungen auf \"Serie\".';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline-Modus';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tippe auf dem Absorbing-Bildschirm auf den Flugzeug-Button, um in den Offline-Modus zu wechseln. Das stoppt die Synchronisierung, spart Daten und zeigt nur deine heruntergeladenen Bücher. Ideal für Flüge oder schlechten Empfang.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tippe auf dem Absorbing-Bildschirm auf den Flugzeug-Button, um in den Offline-Modus zu wechseln. Das stoppt die Synchronisierung, spart Daten und zeigt nur deine heruntergeladenen Bücher. Ideal für Flüge oder schlechten Empfang.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Kommende Veröffentlichungen';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Equalizer pro Buch';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Jedes Buch merkt sich seine eigenen EQ-Einstellungen. Stell den EQ einmal für ein Sci-Fi-Epos ein und beim nächsten Mal klingt es genauso.';
+  String get tipsSheetPerBookEqDesc =>
+      'Jedes Buch merkt sich seine eigenen EQ-Einstellungen. Stell den EQ einmal für ein Sci-Fi-Epos ein und beim nächsten Mal klingt es genauso.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Geschwindigkeit pro Buch';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Die Wiedergabegeschwindigkeit wird pro Buch gespeichert. Sachbücher mit 1,5x und dramatische Romane mit 1,0x hören - ohne es jedes Mal neu einstellen zu müssen.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Die Wiedergabegeschwindigkeit wird pro Buch gespeichert. Sachbücher mit 1,5x und dramatische Romane mit 1,0x hören - ohne es jedes Mal neu einstellen zu müssen.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto-Sleep-Zeitfenster';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Wähle die Stunden, in denen du normalerweise einschläfst, und der Sleep-Timer startet automatisch, wenn du in diesem Fenster zu hören beginnst.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Wähle die Stunden, in denen du normalerweise einschläfst, und der Sleep-Timer startet automatisch, wenn du in diesem Fenster zu hören beginnst.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep-Fade und Klangzeichen';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'Wenn der Sleep-Timer endet, wird das Audio langsam ausgeblendet und ein optionales Klangzeichen ertönt, damit nicht mitten im Satz abgeschnitten wird.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'Wenn der Sleep-Timer endet, wird das Audio langsam ausgeblendet und ein optionales Klangzeichen ertönt, damit nicht mitten im Satz abgeschnitten wird.';
 
   @override
   String get tipsSheetCarModeTitle => 'Auto-Modus';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tippe auf das Auto-Symbol, um in den Modus mit großen Buttons zu wechseln, der für sicherere Bedienung beim Fahren gedacht ist.';
+  String get tipsSheetCarModeDesc =>
+      'Tippe auf das Auto-Symbol, um in den Modus mit großen Buttons zu wechseln, der für sicherere Bedienung beim Fahren gedacht ist.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible-Serien-Suche';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unbekannter Titel';
@@ -5293,7 +5529,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cardEdgeProgressHalfSpeed => 'Halbe Geschwindigkeit';
 
   @override
-  String get authSessionExpired => 'Sitzung abgelaufen. Bitte melde dich erneut an.';
+  String get authSessionExpired =>
+      'Sitzung abgelaufen. Bitte melde dich erneut an.';
 
   @override
   String authCannotReachServer(String url) {
@@ -5301,19 +5538,22 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get authInvalidUsernameOrPassword => 'Ungültiger Benutzername oder Passwort';
+  String get authInvalidUsernameOrPassword =>
+      'Ungültiger Benutzername oder Passwort';
 
   @override
   String get authInvalidApiKey => 'Ungültiger API-Schlüssel';
 
   @override
-  String get authLoginFailedDetail => 'Anmeldung fehlgeschlagen - prüfe Serveradresse und Zugangsdaten';
+  String get authLoginFailedDetail =>
+      'Anmeldung fehlgeschlagen - prüfe Serveradresse und Zugangsdaten';
 
   @override
   String get authUnexpectedServerResponse => 'Unerwartete Server-Antwort';
 
   @override
-  String get authSsoUnexpectedResponse => 'SSO hat eine unerwartete Antwort zurückgegeben';
+  String get authSsoUnexpectedResponse =>
+      'SSO hat eine unerwartete Antwort zurückgegeben';
 
   @override
   String get authSwitchedToLocalServer => 'Zu lokalem Server gewechselt';
@@ -5372,13 +5612,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download-Fortschritt';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Zeigt den Fortschritt während Hörbuch-Downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Zeigt den Fortschritt während Hörbuch-Downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download-Benachrichtigungen';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Benachrichtigungen, wenn Downloads beendet werden oder fehlschlagen';
+  String get downloadNotifAlertChannelDesc =>
+      'Benachrichtigungen, wenn Downloads beendet werden oder fehlschlagen';
 
   @override
   String get downloadNotifDownloadingTitle => 'Wird heruntergeladen…';
@@ -5414,19 +5656,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadNotifFailedTitle => 'Download fehlgeschlagen';
 
   @override
-  String get upcomingNotifChannelName => 'Suche nach kommenden Veröffentlichungen';
+  String get upcomingNotifChannelName =>
+      'Suche nach kommenden Veröffentlichungen';
 
   @override
-  String get upcomingNotifChannelDesc => 'Zeigt den Fortschritt beim Scannen nach kommenden Veröffentlichungen';
+  String get upcomingNotifChannelDesc =>
+      'Zeigt den Fortschritt beim Scannen nach kommenden Veröffentlichungen';
 
   @override
-  String get upcomingNotifScanTitle => 'Suche nach kommenden Veröffentlichungen';
+  String get upcomingNotifScanTitle =>
+      'Suche nach kommenden Veröffentlichungen';
 
   @override
   String get upcomingNotifStartingScan => 'Suche wird gestartet…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Prüfe $seriesName… ($current/$total)';
   }
 
@@ -5466,19 +5712,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showTipsAgain => 'Tipps wieder anzeigen';
 
   @override
-  String get showTipsAgainSubtitle => 'Bringe ausgeblendete Funktions-Tipps zurück';
+  String get showTipsAgainSubtitle =>
+      'Bringe ausgeblendete Funktions-Tipps zurück';
 
   @override
   String get tipsRestored => 'Tipps wiederhergestellt';
 
   @override
-  String get resetSpeedPresets => 'Geschwindigkeits-Voreinstellungen zurücksetzen';
+  String get resetSpeedPresets =>
+      'Geschwindigkeits-Voreinstellungen zurücksetzen';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Standard-Wiedergabegeschwindigkeiten wiederherstellen';
+  String get resetSpeedPresetsSubtitle =>
+      'Standard-Wiedergabegeschwindigkeiten wiederherstellen';
 
   @override
-  String get speedPresetsReset => 'Geschwindigkeits-Voreinstellungen zurückgesetzt';
+  String get speedPresetsReset =>
+      'Geschwindigkeits-Voreinstellungen zurückgesetzt';
 
   @override
   String get editAuthor => 'Autor bearbeiten';
@@ -5496,13 +5746,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authorRemoveImageTitle => 'Autorenbild entfernen?';
 
   @override
-  String get authorRemoveImageConfirm => 'Dadurch wird das Bild auf dem Server gelöscht.';
+  String get authorRemoveImageConfirm =>
+      'Dadurch wird das Bild auf dem Server gelöscht.';
 
   @override
   String get authorImageRemoved => 'Bild entfernt';
 
   @override
-  String get authorImageFailed => 'Das Autorenbild konnte nicht aktualisiert werden';
+  String get authorImageFailed =>
+      'Das Autorenbild konnte nicht aktualisiert werden';
 
   @override
   String get authorUpdated => 'Autor aktualisiert';
@@ -5522,7 +5774,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5802,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5878,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5921,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterShiftBySeconds => 'Verschieben um (Sekunden)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5966,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5992,12 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +6009,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get coverSearchTitle => 'Nach einem Cover suchen';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +6031,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6069,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6078,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6170,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6210,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6304,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6446,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6569,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2242,6 +2242,44 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Aktualisieren';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2075,6 +2075,17 @@ class AppLocalizationsDe extends AppLocalizations {
       'Hol dir eine Login-URL von deinem Server-Admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Hol dir eine Login-URL von deinem Server-Admin. Diese wird in RMAB > Admin > Users generiert.';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -18,8 +18,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get offline => 'Offline';
 
   @override
-  String get stillOffline =>
-      'Immer noch offline. Tippe, um es erneut zu versuchen.';
+  String get stillOffline => 'Immer noch offline. Tippe, um es erneut zu versuchen.';
 
   @override
   String get retry => 'Erneut versuchen';
@@ -121,15 +120,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Deine Bibliothek ist leer';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Lade Bücher herunter, solange du online bist, um sie offline zu hören';
+  String get downloadBooksWhileOnline => 'Lade Bücher herunter, solange du online bist, um sie offline zu hören';
 
   @override
   String get customizeHome => 'Startseite anpassen';
 
   @override
-  String get dragToReorderTapEye =>
-      'Zum Umsortieren ziehen, Auge antippen zum Ein-/Ausblenden';
+  String get dragToReorderTapEye => 'Zum Umsortieren ziehen, Auge antippen zum Ein-/Ausblenden';
 
   @override
   String get loginTagline => 'Start Absorbing';
@@ -144,8 +141,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginServerHint => 'my.server.com';
 
   @override
-  String get loginServerHelper =>
-      'IP:Port funktioniert auch (z. B. 192.168.1.5:13378)';
+  String get loginServerHelper => 'IP:Port funktioniert auch (z. B. 192.168.1.5:13378)';
 
   @override
   String get loginCouldNotReachServer => 'Server nicht erreichbar';
@@ -157,8 +153,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Eigene HTTP-Header';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'Für Cloudflare-Tunnel oder Reverse-Proxys, die zusätzliche Header benötigen. Header hinzufügen, bevor du die Server-URL eingibst.';
+  String get loginCustomHeadersDescription => 'Für Cloudflare-Tunnel oder Reverse-Proxys, die zusätzliche Header benötigen. Header hinzufügen, bevor du die Server-URL eingibst.';
 
   @override
   String get loginHeaderName => 'Header-Name';
@@ -173,15 +168,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Selbstsignierte Zertifikate';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Allen Zertifikaten vertrauen (für selbstsignierte / eigene CA-Setups)';
+  String get loginTrustAllCertificates => 'Allen Zertifikaten vertrauen (für selbstsignierte / eigene CA-Setups)';
 
   @override
   String get loginApiKey => 'API-Schlüssel';
 
   @override
-  String get loginApiKeyDescription =>
-      'Verwende einen vom Admin generierten API-Schlüssel statt Benutzername/Passwort. Praktisch, wenn die Token-Erneuerung für dein Konto fehlschlägt.';
+  String get loginApiKeyDescription => 'Verwende einen vom Admin generierten API-Schlüssel statt Benutzername/Passwort. Praktisch, wenn die Token-Erneuerung für dein Konto fehlschlägt.';
 
   @override
   String get loginWaitingForSso => 'Warte auf SSO...';
@@ -229,12 +222,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -243,8 +234,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -263,8 +253,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loginSsoFailed => 'SSO-Anmeldung fehlgeschlagen oder abgebrochen';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO-Authentifizierung fehlgeschlagen. Bitte versuche es erneut.';
+  String get loginSsoAuthFailed => 'SSO-Authentifizierung fehlgeschlagen. Bitte versuche es erneut.';
 
   @override
   String get loginRestoreFromBackup => 'Aus Backup wiederherstellen';
@@ -281,8 +270,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'Damit werden alle Einstellungen wiederhergestellt. Es waren keine Konten in diesem Backup enthalten.';
+  String get loginRestoreBackupNoAccounts => 'Damit werden alle Einstellungen wiederhergestellt. Es waren keine Konten in diesem Backup enthalten.';
 
   @override
   String get loginRestore => 'Wiederherstellen';
@@ -293,8 +281,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Einstellungen wiederhergestellt. Sitzung abgelaufen - melde dich an, um fortzufahren.';
+  String get loginSessionExpired => 'Einstellungen wiederhergestellt. Sitzung abgelaufen - melde dich an, um fortzufahren.';
 
   @override
   String get loginSettingsRestored => 'Einstellungen wiederhergestellt';
@@ -311,8 +298,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libraryTitle => 'Bibliothek';
 
   @override
-  String get librarySearchBooksHint =>
-      'Bücher, Serien, Autoren, Sprecher suchen...';
+  String get librarySearchBooksHint => 'Bücher, Serien, Autoren, Sprecher suchen...';
 
   @override
   String get librarySearchShowsHint => 'Sendungen und Episoden suchen...';
@@ -498,8 +484,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get absorbingDone => 'Fertig';
 
   @override
-  String get absorbingNoDownloadedEpisodes =>
-      'Keine heruntergeladenen Episoden';
+  String get absorbingNoDownloadedEpisodes => 'Keine heruntergeladenen Episoden';
 
   @override
   String get absorbingNoDownloadedBooks => 'Keine heruntergeladenen Bücher';
@@ -511,20 +496,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Noch nichts am Absorbing';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Episoden herunterladen, um offline zu hören';
+  String get absorbingDownloadEpisodesToListen => 'Episoden herunterladen, um offline zu hören';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Bücher herunterladen, um offline zu hören';
+  String get absorbingDownloadBooksToListen => 'Bücher herunterladen, um offline zu hören';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Starte eine Episode aus dem Sendungen-Tab';
+  String get absorbingStartEpisodeFromShows => 'Starte eine Episode aus dem Sendungen-Tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Starte ein Buch aus dem Bibliothek-Tab';
+  String get absorbingStartBookFromLibrary => 'Starte ein Buch aus dem Bibliothek-Tab';
 
   @override
   String get carModeTitle => 'Auto-Modus';
@@ -580,8 +561,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Heruntergeladene Dateien werden von diesem Gerät entfernt.';
+  String get downloadsDeleteContent => 'Heruntergeladene Dateien werden von diesem Gerät entfernt.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -630,8 +610,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get bookmarksDeleteContent =>
-      'Das kann nicht rückgängig gemacht werden.';
+  String get bookmarksDeleteContent => 'Das kann nicht rückgängig gemacht werden.';
 
   @override
   String bookmarksDeletedCount(int count) {
@@ -913,8 +892,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get languageSystemDefault => 'Systemstandard';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Möchtest du Absorb in deine Sprache übersetzen?';
+  String get languageHelpTranslateInvite => 'Möchtest du Absorb in deine Sprache übersetzen?';
 
   @override
   String get themeLabel => 'Theme';
@@ -935,12 +913,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get colorSourceLabel => 'Farbquelle';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App-Farben richten sich nach dem Cover des aktuell laufenden Buchs';
+  String get colorSourceCoverDescription => 'App-Farben richten sich nach dem Cover des aktuell laufenden Buchs';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App-Farben richten sich nach deinem System-Hintergrundbild';
+  String get colorSourceWallpaperDescription => 'App-Farben richten sich nach deinem System-Hintergrundbild';
 
   @override
   String get colorSourceWallpaper => 'Hintergrundbild';
@@ -955,8 +931,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -965,15 +940,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -982,8 +955,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get startScreenLabel => 'Startbildschirm';
 
   @override
-  String get startScreenSubtitle =>
-      'Welcher Tab beim Start der App geöffnet wird';
+  String get startScreenSubtitle => 'Welcher Tab beim Start der App geöffnet wird';
 
   @override
   String get startScreenHome => 'Start';
@@ -1004,8 +976,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get disablePageFadeOnSubtitle => 'Seiten wechseln sofort';
 
   @override
-  String get disablePageFadeOffSubtitle =>
-      'Seiten blenden beim Tab-Wechsel über';
+  String get disablePageFadeOffSubtitle => 'Seiten blenden beim Tab-Wechsel über';
 
   @override
   String get rectangleBookCovers => 'Rechteckige Buchcover';
@@ -1014,8 +985,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Cover werden im 2:3-Buchformat angezeigt';
+  String get rectangleBookCoversOnSubtitle => 'Cover werden im 2:3-Buchformat angezeigt';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Cover sind quadratisch';
@@ -1027,19 +997,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fullScreenPlayer => 'Vollbild-Player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'An - Bücher öffnen sich beim Abspielen im Vollbild';
+  String get fullScreenPlayerOnSubtitle => 'An - Bücher öffnen sich beim Abspielen im Vollbild';
 
   @override
-  String get fullScreenPlayerOffSubtitle =>
-      'Aus - Wiedergabe in der Kartenansicht';
+  String get fullScreenPlayerOffSubtitle => 'Aus - Wiedergabe in der Kartenansicht';
 
   @override
   String get fullBookScrubber => 'Ganzes-Buch-Scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'An - durchziehbarer Slider über das gesamte Buch';
+  String get fullBookScrubberOnSubtitle => 'An - durchziehbarer Slider über das gesamte Buch';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Aus - nur Fortschrittsbalken';
@@ -1048,8 +1015,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get speedAdjustedTime => 'Geschwindigkeitsangepasste Zeit';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'An - verbleibende Zeit berücksichtigt die Wiedergabegeschwindigkeit';
+  String get speedAdjustedTimeOnSubtitle => 'An - verbleibende Zeit berücksichtigt die Wiedergabegeschwindigkeit';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Aus - zeigt die reine Audiodauer';
@@ -1058,8 +1024,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get buttonLayout => 'Button-Anordnung';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'Wie die Aktions-Buttons auf der Karte angeordnet sind';
+  String get buttonLayoutSubtitle => 'Wie die Aktions-Buttons auf der Karte angeordnet sind';
 
   @override
   String get whenAbsorbed => 'Beim Absorb';
@@ -1068,12 +1033,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'Beim Absorb';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Steuert, was mit einer Absorbing-Karte passiert, wenn du ein Buch oder eine Episode beendest.\n\nBeendete Karten werden automatisch von deinem Absorbing-Bildschirm entfernt.';
+  String get whenAbsorbedInfoContent => 'Steuert, was mit einer Absorbing-Karte passiert, wenn du ein Buch oder eine Episode beendest.\n\nBeendete Karten werden automatisch von deinem Absorbing-Bildschirm entfernt.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'Was mit der Absorbing-Karte passiert, wenn ein Buch oder eine Episode endet';
+  String get whenAbsorbedSubtitle => 'Was mit der Absorbing-Karte passiert, wenn ein Buch oder eine Episode endet';
 
   @override
   String get whenAbsorbedShowOverlay => 'Overlay anzeigen';
@@ -1088,16 +1051,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Bibliotheken zusammenführen';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'Wenn aktiviert, zeigt der Absorbing-Bildschirm alle deine angefangenen Bücher und Podcasts aus jeder Bibliothek in einer Ansicht. Wenn deaktiviert, werden nur Inhalte aus der aktuell ausgewählten Bibliothek angezeigt.';
+  String get mergeLibrariesInfoContent => 'Wenn aktiviert, zeigt der Absorbing-Bildschirm alle deine angefangenen Bücher und Podcasts aus jeder Bibliothek in einer Ansicht. Wenn deaktiviert, werden nur Inhalte aus der aktuell ausgewählten Bibliothek angezeigt.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing-Seite zeigt Inhalte aus allen Bibliotheken';
+  String get mergeLibrariesOnSubtitle => 'Absorbing-Seite zeigt Inhalte aus allen Bibliotheken';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing-Seite zeigt nur die aktuelle Bibliothek';
+  String get mergeLibrariesOffSubtitle => 'Absorbing-Seite zeigt nur die aktuelle Bibliothek';
 
   @override
   String get queueMode => 'Warteschlangenmodus';
@@ -1109,15 +1069,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get queueModeInfoOff => 'Aus';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Die Wiedergabe stoppt, wenn das aktuelle Buch oder die Episode endet.';
+  String get queueModeInfoOffDesc => 'Die Wiedergabe stoppt, wenn das aktuelle Buch oder die Episode endet.';
 
   @override
   String get queueModeInfoManual => 'Manuelle Warteschlange';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Deine Absorbing-Karten funktionieren wie eine Playlist. Wenn eine endet, läuft die nächste noch nicht beendete Karte automatisch weiter. Füge Inhalte über den Button \"Zu Absorbing hinzufügen\" bei einem Buch oder einer Episode hinzu und sortiere sie auf dem Absorbing-Bildschirm um.';
+  String get queueModeInfoManualDesc => 'Deine Absorbing-Karten funktionieren wie eine Playlist. Wenn eine endet, läuft die nächste noch nicht beendete Karte automatisch weiter. Füge Inhalte über den Button \"Zu Absorbing hinzufügen\" bei einem Buch oder einer Episode hinzu und sortiere sie auf dem Absorbing-Bildschirm um.';
 
   @override
   String get queueModeOff => 'Aus';
@@ -1135,8 +1093,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1150,8 +1107,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Beenden';
@@ -1206,8 +1162,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get defaultSpeed => 'Standardgeschwindigkeit';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'Neue Bücher starten mit dieser Geschwindigkeit - jedes Buch merkt sich seine eigene';
+  String get defaultSpeedSubtitle => 'Neue Bücher starten mit dieser Geschwindigkeit - jedes Buch merkt sich seine eigene';
 
   @override
   String get skipBack => 'Zurückspulen';
@@ -1216,46 +1171,37 @@ class AppLocalizationsDe extends AppLocalizations {
   String get skipForward => 'Vorspulen';
 
   @override
-  String get chapterProgressInNotification =>
-      'Kapitelfortschritt in der Benachrichtigung';
+  String get chapterProgressInNotification => 'Kapitelfortschritt in der Benachrichtigung';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'An - Sperrbildschirm zeigt Kapitelfortschritt';
+  String get chapterProgressOnSubtitle => 'An - Sperrbildschirm zeigt Kapitelfortschritt';
 
   @override
-  String get chapterProgressOffSubtitle =>
-      'Aus - Sperrbildschirm zeigt Fortschritt des gesamten Buchs';
+  String get chapterProgressOffSubtitle => 'Aus - Sperrbildschirm zeigt Fortschritt des gesamten Buchs';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-Zurückspulen beim Fortsetzen';
@@ -1281,8 +1227,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rewindAlwaysLabel => 'Immer';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Spult jedes Mal beim Fortsetzen zurück, auch nach kurzen Unterbrechungen';
+  String get rewindAlwaysDescription => 'Spult jedes Mal beim Fortsetzen zurück, auch nach kurzen Unterbrechungen';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1293,8 +1238,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterBarrier => 'Kapitelgrenze';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Nicht über den Anfang des aktuellen Kapitels hinaus zurückspulen';
+  String get chapterBarrierSubtitle => 'Nicht über den Anfang des aktuellen Kapitels hinaus zurückspulen';
 
   @override
   String get rewindInstant => 'Sofort';
@@ -1363,23 +1307,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get resetTimerOnPause => 'Timer bei Pause zurücksetzen';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer startet bei Fortsetzung von der vollen Dauer neu';
+  String get resetTimerOnPauseOnSubtitle => 'Timer startet bei Fortsetzung von der vollen Dauer neu';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer läuft dort weiter, wo er aufgehört hat';
+  String get resetTimerOnPauseOffSubtitle => 'Timer läuft dort weiter, wo er aufgehört hat';
 
   @override
   String get fadeVolumeBeforeSleep => 'Lautstärke vor dem Sleep ausblenden';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Senkt die Lautstärke in den letzten 30 Sekunden allmählich ab';
+  String get fadeVolumeOnSubtitle => 'Senkt die Lautstärke in den letzten 30 Sekunden allmählich ab';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Wiedergabe stoppt sofort, wenn der Timer endet';
+  String get fadeVolumeOffSubtitle => 'Wiedergabe stoppt sofort, wenn der Timer endet';
 
   @override
   String get autoSleepTimer => 'Automatischer Sleep-Timer';
@@ -1390,8 +1330,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Sleep-Timer in einem Zeitfenster automatisch starten';
+  String get autoSleepTimerOffSubtitle => 'Sleep-Timer in einem Zeitfenster automatisch starten';
 
   @override
   String get windowStart => 'Fensterbeginn';
@@ -1436,12 +1375,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadOverWifiOnly => 'Nur über WLAN herunterladen';
 
   @override
-  String get downloadOverWifiOnSubtitle =>
-      'An - mobile Daten für Downloads blockiert';
+  String get downloadOverWifiOnSubtitle => 'An - mobile Daten für Downloads blockiert';
 
   @override
-  String get downloadOverWifiOffSubtitle =>
-      'Aus - Downloads über jede Verbindung';
+  String get downloadOverWifiOffSubtitle => 'Aus - Downloads über jede Verbindung';
 
   @override
   String get autoDownloadOnWifi => 'Auto-Download im WLAN';
@@ -1450,12 +1387,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download im WLAN';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'Wenn du ein Buch über WLAN streamst, wird das vollständige Buch automatisch im Hintergrund heruntergeladen. So hast du es offline verfügbar, ohne den Download manuell starten zu müssen.';
+  String get autoDownloadOnWifiInfoContent => 'Wenn du ein Buch über WLAN streamst, wird das vollständige Buch automatisch im Hintergrund heruntergeladen. So hast du es offline verfügbar, ohne den Download manuell starten zu müssen.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Bücher werden im Hintergrund heruntergeladen, wenn du im WLAN streamst';
+  String get autoDownloadOnWifiOnSubtitle => 'Bücher werden im Hintergrund heruntergeladen, wenn du im WLAN streamst';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Aus';
@@ -1467,8 +1402,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoDownload => 'Auto-Download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Pro Serie oder Podcast über deren Detailseiten aktivieren';
+  String get autoDownloadSubtitle => 'Pro Serie oder Podcast über deren Detailseiten aktivieren';
 
   @override
   String get keepNext => 'Nächste behalten';
@@ -1477,8 +1411,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get keepNextInfoTitle => 'Nächste behalten';
 
   @override
-  String get keepNextInfoContent =>
-      'Die Anzahl der Elemente, die heruntergeladen bleiben sollen, einschließlich des Elements, das du gerade hörst. Beispiel: \"Nächste 3 behalten\" bedeutet, das aktuelle Buch plus die nächsten 2 in der Serie oder im Podcast bleiben heruntergeladen.';
+  String get keepNextInfoContent => 'Die Anzahl der Elemente, die heruntergeladen bleiben sollen, einschließlich des Elements, das du gerade hörst. Beispiel: \"Nächste 3 behalten\" bedeutet, das aktuelle Buch plus die nächsten 2 in der Serie oder im Podcast bleiben heruntergeladen.';
 
   @override
   String get deleteAbsorbedDownloads => 'Absorbed Downloads löschen';
@@ -1487,16 +1420,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Absorbed Downloads löschen';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'Wenn aktiviert, werden heruntergeladene Bücher oder Episoden automatisch von deinem Gerät gelöscht, nachdem du sie zu Ende gehört hast. Das hilft, Speicherplatz freizugeben, während du dich durch deine Bibliothek arbeitest.';
+  String get deleteAbsorbedDownloadsInfoContent => 'Wenn aktiviert, werden heruntergeladene Bücher oder Episoden automatisch von deinem Gerät gelöscht, nachdem du sie zu Ende gehört hast. Das hilft, Speicherplatz freizugeben, während du dich durch deine Bibliothek arbeitest.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Beendete Elemente werden entfernt, um Platz zu sparen';
+  String get deleteAbsorbedOnSubtitle => 'Beendete Elemente werden entfernt, um Platz zu sparen';
 
   @override
-  String get deleteAbsorbedOffSubtitle =>
-      'Aus - beendete Downloads werden behalten';
+  String get deleteAbsorbedOffSubtitle => 'Aus - beendete Downloads werden behalten';
 
   @override
   String get downloadLocation => 'Download-Speicherort';
@@ -1524,15 +1454,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming-Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Cached gestreamtes Audio auf der Festplatte, damit es nicht erneut heruntergeladen werden muss, wenn du zurückspulst oder Abschnitte erneut hörst. Der Cache wird automatisch verwaltet - älteste Dateien werden entfernt, wenn die Größenbegrenzung erreicht ist. Das ist getrennt von vollständig heruntergeladenen Büchern.';
+  String get streamingCacheInfoContent => 'Cached gestreamtes Audio auf der Festplatte, damit es nicht erneut heruntergeladen werden muss, wenn du zurückspulst oder Abschnitte erneut hörst. Der Cache wird automatisch verwaltet - älteste Dateien werden entfernt, wenn die Größenbegrenzung erreicht ist. Das ist getrennt von vollständig heruntergeladenen Büchern.';
 
   @override
   String get streamingCacheOff => 'Aus';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Aus - Audio wird ohne Caching gestreamt';
+  String get streamingCacheOffSubtitle => 'Aus - Audio wird ohne Caching gestreamt';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1552,19 +1480,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get hideEbookOnlyTitles => 'Nur-eBook-Titel ausblenden';
 
   @override
-  String get hideEbookOnlyOnSubtitle =>
-      'Bücher ohne Audiodateien werden ausgeblendet';
+  String get hideEbookOnlyOnSubtitle => 'Bücher ohne Audiodateien werden ausgeblendet';
 
   @override
-  String get hideEbookOnlyOffSubtitle =>
-      'Aus - alle Bibliothekselemente werden angezeigt';
+  String get hideEbookOnlyOffSubtitle => 'Aus - alle Bibliothekselemente werden angezeigt';
 
   @override
   String get showGoodreadsButton => 'Goodreads-Button anzeigen';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Buchdetails zeigen einen Link zu Goodreads';
+  String get showGoodreadsOnSubtitle => 'Buchdetails zeigen einen Link zu Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Aus - Goodreads-Button ausgeblendet';
@@ -1576,23 +1501,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get notifications => 'Benachrichtigungen';
 
   @override
-  String get notificationsSubtitle =>
-      'Für Download-Fortschritt und Wiedergabesteuerung';
+  String get notificationsSubtitle => 'Für Download-Fortschritt und Wiedergabesteuerung';
 
   @override
-  String get notificationsAlreadyEnabled =>
-      'Benachrichtigungen sind bereits aktiviert';
+  String get notificationsAlreadyEnabled => 'Benachrichtigungen sind bereits aktiviert';
 
   @override
   String get unrestrictedBattery => 'Uneingeschränkte Akkunutzung';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Verhindert, dass Android die Hintergrundwiedergabe beendet';
+  String get unrestrictedBatterySubtitle => 'Verhindert, dass Android die Hintergrundwiedergabe beendet';
 
   @override
-  String get batteryAlreadyUnrestricted =>
-      'Akkunutzung ist bereits uneingeschränkt';
+  String get batteryAlreadyUnrestricted => 'Akkunutzung ist bereits uneingeschränkt';
 
   @override
   String get sectionIssuesAndSupport => 'Probleme & Support';
@@ -1619,19 +1540,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enableLogging => 'Logging aktivieren';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'An - Logs werden in Datei gespeichert (Neustart nötig)';
+  String get enableLoggingOnSubtitle => 'An - Logs werden in Datei gespeichert (Neustart nötig)';
 
   @override
   String get enableLoggingOffSubtitle => 'Aus - keine Logs werden erfasst';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging aktiviert - App neu starten, um Aufzeichnung zu beginnen';
+  String get loggingEnabledSnackbar => 'Logging aktiviert - App neu starten, um Aufzeichnung zu beginnen';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging deaktiviert - App neu starten, um Aufzeichnung zu beenden';
+  String get loggingDisabledSnackbar => 'Logging deaktiviert - App neu starten, um Aufzeichnung zu beenden';
 
   @override
   String get sendLogs => 'Logs senden';
@@ -1660,19 +1578,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get localServerInfoTitle => 'Lokaler Server';
 
   @override
-  String get localServerInfoContent =>
-      'Wenn du deinen Audiobookshelf-Server zu Hause betreibst, kannst du hier eine lokale/LAN-URL festlegen. Absorb wechselt automatisch zur schnelleren lokalen Verbindung, wenn erkannt wird, dass du in deinem Heimnetzwerk bist, und greift unterwegs auf deine Remote-URL zurück.';
+  String get localServerInfoContent => 'Wenn du deinen Audiobookshelf-Server zu Hause betreibst, kannst du hier eine lokale/LAN-URL festlegen. Absorb wechselt automatisch zur schnelleren lokalen Verbindung, wenn erkannt wird, dass du in deinem Heimnetzwerk bist, und greift unterwegs auf deine Remote-URL zurück.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Verbunden über lokalen Server';
 
   @override
-  String get localServerOnRemoteSubtitle =>
-      'Aktiviert - Remote-Server wird verwendet';
+  String get localServerOnRemoteSubtitle => 'Aktiviert - Remote-Server wird verwendet';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-Wechsel zu LAN-Server in deinem Heim-WLAN';
+  String get localServerOffSubtitle => 'Auto-Wechsel zu LAN-Server in deinem Heim-WLAN';
 
   @override
   String get localServerUrlLabel => 'URL des lokalen Servers';
@@ -1681,8 +1596,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'URL des lokalen Servers gesetzt - verbindet sich automatisch in deinem Heimnetzwerk';
+  String get localServerUrlSetSnackbar => 'URL des lokalen Servers gesetzt - verbindet sich automatisch in deinem Heimnetzwerk';
 
   @override
   String get disableAudioFocus => 'Audiofokus deaktivieren';
@@ -1691,23 +1605,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audiofokus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'Standardmäßig gibt Android jeweils einer App den Audio-\"Fokus\" - wenn Absorb spielt, pausiert anderes Audio (Musik, Videos). Wenn du den Audiofokus deaktivierst, kann Absorb neben anderen Apps wiedergegeben werden. Telefonate pausieren die Wiedergabe unabhängig von dieser Einstellung trotzdem.';
+  String get disableAudioFocusInfoContent => 'Standardmäßig gibt Android jeweils einer App den Audio-\"Fokus\" - wenn Absorb spielt, pausiert anderes Audio (Musik, Videos). Wenn du den Audiofokus deaktivierst, kann Absorb neben anderen Apps wiedergegeben werden. Telefonate pausieren die Wiedergabe unabhängig von dieser Einstellung trotzdem.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'An - spielt neben anderem Audio (pausiert weiterhin bei Anrufen)';
+  String get disableAudioFocusOnSubtitle => 'An - spielt neben anderem Audio (pausiert weiterhin bei Anrufen)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Aus - anderes Audio pausiert, wenn Absorb spielt';
+  String get disableAudioFocusOffSubtitle => 'Aus - anderes Audio pausiert, wenn Absorb spielt';
 
   @override
   String get restartRequired => 'Neustart erforderlich';
 
   @override
-  String get restartRequiredContent =>
-      'Die Änderung des Audiofokus erfordert einen vollständigen Neustart. App jetzt schließen?';
+  String get restartRequiredContent => 'Die Änderung des Audiofokus erfordert einen vollständigen Neustart. App jetzt schließen?';
 
   @override
   String get closeApp => 'App schließen';
@@ -1719,16 +1629,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Selbstsignierte Zertifikate';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Aktiviere dies, wenn dein Audiobookshelf-Server ein selbstsigniertes Zertifikat oder eine eigene Root-CA verwendet. Wenn aktiviert, überspringt Absorb die TLS-Zertifikatsprüfung für alle Verbindungen. Aktiviere dies nur, wenn du deinem Netzwerk vertraust.';
+  String get trustAllCertificatesInfoContent => 'Aktiviere dies, wenn dein Audiobookshelf-Server ein selbstsigniertes Zertifikat oder eine eigene Root-CA verwendet. Wenn aktiviert, überspringt Absorb die TLS-Zertifikatsprüfung für alle Verbindungen. Aktiviere dies nur, wenn du deinem Netzwerk vertraust.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'An - alle Zertifikate werden akzeptiert';
+  String get trustAllCertificatesOnSubtitle => 'An - alle Zertifikate werden akzeptiert';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Aus - nur vertrauenswürdige Zertifikate akzeptiert';
+  String get trustAllCertificatesOffSubtitle => 'Aus - nur vertrauenswürdige Zertifikate akzeptiert';
 
   @override
   String get supportTheDev => 'Den Entwickler unterstützen';
@@ -1750,8 +1657,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backupAndRestore => 'Sichern & Wiederherstellen';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Alle Einstellungen in einer Datei speichern oder wiederherstellen';
+  String get backupAndRestoreSubtitle => 'Alle Einstellungen in einer Datei speichern oder wiederherstellen';
 
   @override
   String get backUp => 'Sichern';
@@ -1778,8 +1684,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get includeLoginInfoTitle => 'Login-Daten einschließen?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Möchtest du die Login-Daten aller deiner gespeicherten Konten in die Sicherung einschließen?\n\nDas erleichtert die Wiederherstellung auf einem neuen Gerät, aber die Datei enthält dann deine Auth-Tokens.';
+  String get includeLoginInfoContent => 'Möchtest du die Login-Daten aller deiner gespeicherten Konten in die Sicherung einschließen?\n\nDas erleichtert die Wiederherstellung auf einem neuen Gerät, aber die Datei enthält dann deine Auth-Tokens.';
 
   @override
   String get noSettingsOnly => 'Nein, nur Einstellungen';
@@ -1791,8 +1696,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backupSavedWithAccounts => 'Sicherung gespeichert (mit Konten)';
 
   @override
-  String get backupSavedSettingsOnly =>
-      'Sicherung gespeichert (nur Einstellungen)';
+  String get backupSavedSettingsOnly => 'Sicherung gespeichert (nur Einstellungen)';
 
   @override
   String backupFailed(String error) {
@@ -1803,8 +1707,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get restoreBackupTitle => 'Sicherung wiederherstellen?';
 
   @override
-  String get restoreBackupContent =>
-      'Dadurch werden alle deine aktuellen Einstellungen durch die Werte aus der Sicherung ersetzt.';
+  String get restoreBackupContent => 'Dadurch werden alle deine aktuellen Einstellungen durch die Werte aus der Sicherung ersetzt.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1828,8 +1731,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get invalidBackupFile => 'Ungültige Sicherungsdatei';
 
   @override
-  String get settingsRestoredSuccessfully =>
-      'Einstellungen erfolgreich wiederhergestellt';
+  String get settingsRestoredSuccessfully => 'Einstellungen erfolgreich wiederhergestellt';
 
   @override
   String restoreFailed(String error) {
@@ -1840,8 +1742,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get logOutTitle => 'Abmelden?';
 
   @override
-  String get logOutContent =>
-      'Du wirst abgemeldet. Deine Downloads bleiben auf diesem Gerät.';
+  String get logOutContent => 'Du wirst abgemeldet. Deine Downloads bleiben auf diesem Gerät.';
 
   @override
   String get signOut => 'Abmelden';
@@ -1892,15 +1793,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download-Speicherort';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Wähle, wo Hörbücher gespeichert werden';
+  String get downloadLocationSheetSubtitle => 'Wähle, wo Hörbücher gespeichert werden';
 
   @override
   String get currentLocation => 'Aktueller Speicherort';
 
   @override
-  String get existingDownloadsWarning =>
-      'Vorhandene Downloads bleiben an ihrem aktuellen Speicherort. Nur neue Downloads verwenden den neuen Pfad.';
+  String get existingDownloadsWarning => 'Vorhandene Downloads bleiben an ihrem aktuellen Speicherort. Nur neue Downloads verwenden den neuen Pfad.';
 
   @override
   String get chooseFolder => 'Ordner wählen';
@@ -1909,19 +1808,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chooseDownloadFolder => 'Download-Ordner wählen';
 
   @override
-  String get storagePermissionDenied =>
-      'Speicherberechtigung dauerhaft verweigert - aktiviere sie in den App-Einstellungen';
+  String get storagePermissionDenied => 'Speicherberechtigung dauerhaft verweigert - aktiviere sie in den App-Einstellungen';
 
   @override
   String get openSettings => 'Einstellungen öffnen';
 
   @override
-  String get storagePermissionRequired =>
-      'Speicherberechtigung ist für eigene Download-Speicherorte erforderlich';
+  String get storagePermissionRequired => 'Speicherberechtigung ist für eigene Download-Speicherorte erforderlich';
 
   @override
-  String get cannotWriteToFolder =>
-      'Kann nicht in diesen Ordner schreiben - wähle einen anderen Speicherort oder gewähre in den Systemeinstellungen Dateizugriff';
+  String get cannotWriteToFolder => 'Kann nicht in diesen Ordner schreiben - wähle einen anderen Speicherort oder gewähre in den Systemeinstellungen Dateizugriff';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1939,10 +1835,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1995,8 +1889,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcasts => 'Podcasts';
 
   @override
-  String get adminPodcastsSubtitle =>
-      'Sendungen suchen, hinzufügen & verwalten';
+  String get adminPodcastsSubtitle => 'Sendungen suchen, hinzufügen & verwalten';
 
   @override
   String get adminScan => 'Scannen';
@@ -2045,8 +1938,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook-URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Füge deine URL mit Login-Token ein. Generiere eine in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Füge deine URL mit Login-Token ein. Generiere eine in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2064,15 +1956,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminRmabReload => 'Neu laden';
 
   @override
-  String get adminRmabLoadFailed =>
-      'ReadMeABook konnte nicht geladen werden. Prüfe deine URL.';
+  String get adminRmabLoadFailed => 'ReadMeABook konnte nicht geladen werden. Prüfe deine URL.';
 
   @override
   String get adminRmabConnected => 'Verbunden';
 
   @override
-  String get adminRmabAskAdmin =>
-      'Hol dir eine Login-URL von deinem Server-Admin';
+  String get adminRmabAskAdmin => 'Hol dir eine Login-URL von deinem Server-Admin';
 
   @override
   String adminRmabApprovalsPending(int count) {
@@ -2086,23 +1976,19 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Hol dir eine Login-URL von deinem Server-Admin. Diese wird in RMAB > Admin > Users generiert.';
+  String get adminRmabUrlHelpUser => 'Hol dir eine Login-URL von deinem Server-Admin. Diese wird in RMAB > Admin > Users generiert.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook ist ein selbst gehosteter Dienst zum Anfordern und Herunterladen von Hörbüchern. Es muss von deinem Server-Admin installiert und eingerichtet werden.';
+  String get adminRmabSettingsInfo => 'ReadMeABook ist ein selbst gehosteter Dienst zum Anfordern und Herunterladen von Hörbüchern. Es muss von deinem Server-Admin installiert und eingerichtet werden.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2126,8 +2012,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Verbinden';
@@ -2153,15 +2038,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token vom Server abgelehnt';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
 
   @override
-  String get rmabConfigErrorGeneric =>
-      'Verbindung konnte nicht hergestellt werden';
+  String get rmabConfigErrorGeneric => 'Verbindung konnte nicht hergestellt werden';
 
   @override
   String get rmabConfigSavedSnackbar => 'ReadMeABook connected';
@@ -2196,8 +2079,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Bereits in deiner Bibliothek';
@@ -2224,8 +2106,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2234,8 +2115,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'Meine Anfragen';
@@ -2262,8 +2142,29 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2464,8 +2365,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'Info';
@@ -2497,51 +2397,43 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get markAsFullyAbsorbedQuestion =>
-      'Als vollständig Absorbed markieren?';
+  String get markAsFullyAbsorbedQuestion => 'Als vollständig Absorbed markieren?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'Dadurch wird dein Fortschritt auf 100% gesetzt und die Wiedergabe gestoppt, falls dieses Buch gerade läuft.';
+  String get markAsFullyAbsorbedContent => 'Dadurch wird dein Fortschritt auf 100% gesetzt und die Wiedergabe gestoppt, falls dieses Buch gerade läuft.';
 
   @override
   String get markedAsFinishedNiceWork => 'Als beendet markiert - gut gemacht!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Aktualisieren fehlgeschlagen - prüfe deine Verbindung';
+  String get failedToUpdateCheckConnection => 'Aktualisieren fehlgeschlagen - prüfe deine Verbindung';
 
   @override
   String get markAsNotFinishedQuestion => 'Als nicht beendet markieren?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'Dadurch wird der Beendet-Status entfernt, deine aktuelle Position bleibt aber erhalten.';
+  String get markAsNotFinishedContent => 'Dadurch wird der Beendet-Status entfernt, deine aktuelle Position bleibt aber erhalten.';
 
   @override
   String get unmark => 'Markierung entfernen';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Als nicht beendet markiert - weiter geht\'s!';
+  String get markedAsNotFinishedBackAtIt => 'Als nicht beendet markiert - weiter geht\'s!';
 
   @override
   String get resetProgressQuestion => 'Fortschritt zurücksetzen?';
 
   @override
-  String get resetProgressContent =>
-      'Dadurch wird der gesamte Fortschritt für dieses Buch gelöscht und es auf den Anfang zurückgesetzt. Das kann nicht rückgängig gemacht werden.';
+  String get resetProgressContent => 'Dadurch wird der gesamte Fortschritt für dieses Buch gelöscht und es auf den Anfang zurückgesetzt. Das kann nicht rückgängig gemacht werden.';
 
   @override
-  String get progressResetFreshStart =>
-      'Fortschritt zurückgesetzt - frischer Start!';
+  String get progressResetFreshStart => 'Fortschritt zurückgesetzt - frischer Start!';
 
   @override
   String get clearLocalMetadataQuestion => 'Lokale Metadaten löschen?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'Dadurch werden die lokal gespeicherten Metadaten entfernt und auf das zurückgesetzt, was der Server hat.';
+  String get clearLocalMetadataContent => 'Dadurch werden die lokal gespeicherten Metadaten entfernt und auf das zurückgesetzt, was der Server hat.';
 
   @override
   String get localMetadataCleared => 'Lokale Metadaten gelöscht';
@@ -2570,8 +2462,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noBookmarksYet => 'Noch keine Lesezeichen';
 
   @override
-  String get longPressBookmarkHint =>
-      'Lange auf den Lesezeichen-Button drücken zum schnellen Speichern';
+  String get longPressBookmarkHint => 'Lange auf den Lesezeichen-Button drücken zum schnellen Speichern';
 
   @override
   String get addBookmark => 'Lesezeichen hinzufügen';
@@ -2604,8 +2495,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get clearHistoryTooltip => 'Verlauf löschen';
 
   @override
-  String get tapEventToJump =>
-      'Tippe auf ein Ereignis, um zu dieser Position zu springen';
+  String get tapEventToJump => 'Tippe auf ein Ereignis, um zu dieser Position zu springen';
 
   @override
   String get noHistoryYet => 'Noch kein Verlauf';
@@ -2655,8 +2545,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoDownloadThisSeries => 'Diese Serie automatisch herunterladen?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Lädt die nächsten Bücher beim Hören automatisch herunter.';
+  String get autoDownloadSeriesContent => 'Lädt die nächsten Bücher beim Hören automatisch herunter.';
 
   @override
   String get standalone => 'Eigenständig';
@@ -2691,12 +2580,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get selectAll => 'Alle auswählen';
 
   @override
-  String get autoDownloadThisPodcast =>
-      'Diesen Podcast automatisch herunterladen?';
+  String get autoDownloadThisPodcast => 'Diesen Podcast automatisch herunterladen?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Lädt die nächsten Episoden beim Hören automatisch herunter.';
+  String get autoDownloadPodcastContent => 'Lädt die nächsten Episoden beim Hören automatisch herunter.';
 
   @override
   String get download => 'Herunterladen';
@@ -2723,8 +2610,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authorOptionalLabel => 'Autor (optional)';
 
   @override
-  String get noResultsFound =>
-      'Keine Ergebnisse gefunden.\nPasse deine Suche oder den Anbieter an.';
+  String get noResultsFound => 'Keine Ergebnisse gefunden.\nPasse deine Suche oder den Anbieter an.';
 
   @override
   String get searchForMetadataAbove => 'Oben nach Metadaten suchen';
@@ -2736,8 +2622,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get metadataUpdated => 'Metadaten aktualisiert';
 
   @override
-  String get failedToUpdateMetadata =>
-      'Metadaten konnten nicht aktualisiert werden';
+  String get failedToUpdateMetadata => 'Metadaten konnten nicht aktualisiert werden';
 
   @override
   String get subtitleLabel => 'Untertitel';
@@ -2875,15 +2760,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteCollection => 'Sammlung löschen';
 
   @override
-  String get deleteCollectionContent =>
-      'Möchtest du diese Sammlung wirklich löschen?';
+  String get deleteCollectionContent => 'Möchtest du diese Sammlung wirklich löschen?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist nicht gefunden';
@@ -2892,8 +2775,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deletePlaylist => 'Playlist löschen';
 
   @override
-  String get deletePlaylistContent =>
-      'Möchtest du diese Playlist wirklich löschen?';
+  String get deletePlaylistContent => 'Möchtest du diese Playlist wirklich löschen?';
 
   @override
   String get newPlaylist => 'Neue Playlist';
@@ -2946,8 +2828,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'Wir verwenden \"Absorb\" anstelle von \"abspielen\" und \"hören\".';
+  String get welcomeAbsorbingIntro => 'Wir verwenden \"Absorb\" anstelle von \"abspielen\" und \"hören\".';
 
   @override
   String get welcomeAbsorbingTabBullet => 'Absorbing-Tab - was du gerade hörst';
@@ -2962,15 +2843,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Zurechtfinden';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tippe auf ein Cover, um die Details zu öffnen. Weiterhören-Karten sind anders - tippe für sofortige Wiedergabe, lange drücken für Details.';
+  String get welcomeGettingAroundBody => 'Tippe auf ein Cover, um die Details zu öffnen. Weiterhören-Karten sind anders - tippe für sofortige Wiedergabe, lange drücken für Details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Mach es zu deinem';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Stöbere in den Einstellungen und passe Absorb deinem Geschmack an. Der Bereich Tipps & versteckte Funktionen lohnt sich auf jeden Fall.';
+  String get welcomeMakeItYoursBody => 'Stöbere in den Einstellungen und passe Absorb deinem Geschmack an. Der Bereich Tipps & versteckte Funktionen lohnt sich auf jeden Fall.';
 
   @override
   String get getStarted => 'Los geht\'s';
@@ -3021,8 +2900,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get serverAdmin => 'Server-Admin';
 
   @override
-  String get serverAdminSubtitle =>
-      'Benutzer, Bibliotheken & Server-Einstellungen verwalten';
+  String get serverAdminSubtitle => 'Benutzer, Bibliotheken & Server-Einstellungen verwalten';
 
   @override
   String get justNow => 'Gerade eben';
@@ -3058,12 +2936,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get coverPlayPause => 'Cover Play/Pause';
 
   @override
-  String get coverPlayPauseOnSubtitle =>
-      'An - tippe auf das Cover für Play/Pause';
+  String get coverPlayPauseOnSubtitle => 'An - tippe auf das Cover für Play/Pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Aus - eigener Play/Pause-Button in den Steuerelementen';
+  String get coverPlayPauseOffSubtitle => 'Aus - eigener Play/Pause-Button in den Steuerelementen';
 
   @override
   String get cardBackground => 'Card background';
@@ -3075,8 +2951,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Wiedergabe stoppt, manuelle Warteschlange oder Auto-Absorb des nächsten Elements';
+  String get queueModeMergedSubtitle => 'Wiedergabe stoppt, manuelle Warteschlange oder Auto-Absorb des nächsten Elements';
 
   @override
   String get queueModeSeriesLabel => 'Serie';
@@ -3088,15 +2963,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get queueModeInfoSeries => 'Serie';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Spielt automatisch das nächste Buch einer Serie oder die nächste Episode einer Podcast-Sendung ab.';
+  String get queueModeInfoSeriesDesc => 'Spielt automatisch das nächste Buch einer Serie oder die nächste Episode einer Podcast-Sendung ab.';
 
   @override
   String get resetButtonGridQuestion => 'Button-Raster zurücksetzen?';
 
   @override
-  String get resetButtonGridContent =>
-      'Dies stellt das Standard-Button-Layout, die Reihenfolge und die Schaltereinstellungen wieder her.';
+  String get resetButtonGridContent => 'Dies stellt das Standard-Button-Layout, die Reihenfolge und die Schaltereinstellungen wieder her.';
 
   @override
   String get reset => 'Zurücksetzen';
@@ -3114,16 +2987,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Kapitelgrenze';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'Beim Zurückspulen springt die Wiedergabe an den Anfang des aktuellen Kapitels, statt ins vorherige zu wechseln.\n\nTippe innerhalb von 2 Sekunden zweimal auf den Zurückspulen-Button, um die Grenze zu durchbrechen.';
+  String get chapterBarrierInfoContent => 'Beim Zurückspulen springt die Wiedergabe an den Anfang des aktuellen Kapitels, statt ins vorherige zu wechseln.\n\nTippe innerhalb von 2 Sekunden zweimal auf den Zurückspulen-Button, um die Grenze zu durchbrechen.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'An - Zurückspulen springt zum Kapitelanfang';
+  String get chapterBarrierOnRewindOnSubtitle => 'An - Zurückspulen springt zum Kapitelanfang';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Aus - Zurückspulen überschreitet Kapitelgrenzen';
+  String get chapterBarrierOnRewindOffSubtitle => 'Aus - Zurückspulen überschreitet Kapitelgrenzen';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3134,8 +3004,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get rewindOnSessionStart => 'Zurückspulen bei Sitzungsstart';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Das normale Auto-Zurückspulen wird ausgelöst, wenn du innerhalb einer aktiven Sitzung aus einer Pause fortsetzt. Diese Einstellung fügt ein Zurückspulen beim Start einer komplett neuen Sitzung hinzu - zum Beispiel nach dem Schließen der App, gestoppter Wiedergabe oder beim frischen Öffnen der App.\n\nWenn aktiviert, springt die Wiedergabe zu Beginn jeder neuen Sitzung um den vollen maximalen Zurückspul-Wert zurück, damit du noch einmal hörst, wo du aufgehört hast.';
+  String get rewindOnSessionStartInfoContent => 'Das normale Auto-Zurückspulen wird ausgelöst, wenn du innerhalb einer aktiven Sitzung aus einer Pause fortsetzt. Diese Einstellung fügt ein Zurückspulen beim Start einer komplett neuen Sitzung hinzu - zum Beispiel nach dem Schließen der App, gestoppter Wiedergabe oder beim frischen Öffnen der App.\n\nWenn aktiviert, springt die Wiedergabe zu Beginn jeder neuen Sitzung um den vollen maximalen Zurückspul-Wert zurück, damit du noch einmal hörst, wo du aufgehört hast.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3189,8 +3058,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chimeBeforeSleep => 'Glocke vor Sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Spielt eine sanfte Glocke, bevor der Timer endet';
+  String get chimeBeforeSleepOnSubtitle => 'Spielt eine sanfte Glocke, bevor der Timer endet';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'Keine Tonwarnung vor Sleep';
@@ -3209,8 +3077,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start - $end · $duration';
   }
 
@@ -3227,12 +3094,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showExplicitBadge => 'Explicit-Abzeichen anzeigen';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit-Inhalte zeigen ein \"E\"-Abzeichen';
+  String get showExplicitBadgeOnSubtitle => 'Explicit-Inhalte zeigen ein \"E\"-Abzeichen';
 
   @override
-  String get showExplicitBadgeOffSubtitle =>
-      'Aus - Explicit-Abzeichen ausgeblendet';
+  String get showExplicitBadgeOffSubtitle => 'Aus - Explicit-Abzeichen ausgeblendet';
 
   @override
   String get libraryFallback => 'Bibliothek';
@@ -3241,15 +3106,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-Release-Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'Wenn aktiviert, informiert dich der Update-Checker auch über Alpha- und Pre-Release-Builds von GitHub. Diese können instabiler sein, enthalten aber die neuesten Funktionen und Korrekturen.';
+  String get preReleaseUpdatesInfoContent => 'Wenn aktiviert, informiert dich der Update-Checker auch über Alpha- und Pre-Release-Builds von GitHub. Diese können instabiler sein, enthalten aber die neuesten Funktionen und Korrekturen.';
 
   @override
   String get includePreReleases => 'Pre-Releases einbeziehen';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'An - sucht nach Alpha- & Pre-Release-Builds';
+  String get includePreReleasesOnSubtitle => 'An - sucht nach Alpha- & Pre-Release-Builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Aus - nur stabile Versionen';
@@ -3290,12 +3153,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get updateDownloading => 'Update wird heruntergeladen...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
-  String get updateOpeningInBrowser =>
-      'Das In-App-Update ist fehlgeschlagen, Browser wird geöffnet';
+  String get updateOpeningInBrowser => 'Das In-App-Update ist fehlgeschlagen, Browser wird geöffnet';
 
   @override
   String get sendToEreader => 'An E-Reader senden';
@@ -3362,8 +3223,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get smtpSaved => 'E-Mail-Einstellungen gespeichert';
 
   @override
-  String get smtpSaveFailed =>
-      'Die E-Mail-Einstellungen konnten nicht gespeichert werden';
+  String get smtpSaveFailed => 'Die E-Mail-Einstellungen konnten nicht gespeichert werden';
 
   @override
   String get smtpTestSent => 'Test-E-Mail gesendet';
@@ -3375,8 +3235,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ereaderDevicesTitle => 'E-Reader-Geräte';
 
   @override
-  String get ereaderDevicesEmpty =>
-      'Noch keine Geräte. Füge unten eines hinzu.';
+  String get ereaderDevicesEmpty => 'Noch keine Geräte. Füge unten eines hinzu.';
 
   @override
   String get addEreaderDevice => 'Gerät hinzufügen';
@@ -3417,8 +3276,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ereaderDevicesSaved => 'Geräte gespeichert';
 
   @override
-  String get ereaderDevicesSaveFailed =>
-      'Geräte konnten nicht gespeichert werden';
+  String get ereaderDevicesSaveFailed => 'Geräte konnten nicht gespeichert werden';
 
   @override
   String libraryCountOne(int count) {
@@ -3449,8 +3307,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Nach Position sortiert (umgekehrt)';
+  String get bookmarksSortedByPositionReversed => 'Nach Position sortiert (umgekehrt)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3529,8 +3386,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Zurücksetzen wurde möglicherweise nicht synchronisiert - prüfe deinen Server';
+  String get resetMayNotHaveSynced => 'Zurücksetzen wurde möglicherweise nicht synchronisiert - prüfe deinen Server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3538,8 +3394,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Der Server hat eine Fehlerseite statt der E-Book-Datei zurückgegeben';
+  String get serverReturnedErrorPage => 'Der Server hat eine Fehlerseite statt der E-Book-Datei zurückgegeben';
 
   @override
   String ebookSaved(String filename) {
@@ -3672,8 +3527,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersEnterPassword => 'Passwort eingeben';
 
   @override
-  String get adminUsersLeaveBlankToKeep =>
-      'Leer lassen, um aktuelles zu behalten';
+  String get adminUsersLeaveBlankToKeep => 'Leer lassen, um aktuelles zu behalten';
 
   @override
   String get adminUsersAccountType => 'Kontotyp';
@@ -3694,8 +3548,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersAccountActive => 'Konto aktiv';
 
   @override
-  String get adminUsersAccountActiveSub =>
-      'Deaktivierte Konten können sich nicht anmelden';
+  String get adminUsersAccountActiveSub => 'Deaktivierte Konten können sich nicht anmelden';
 
   @override
   String get adminUsersLocked => 'Gesperrt';
@@ -3713,8 +3566,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersPermUpdate => 'Aktualisieren';
 
   @override
-  String get adminUsersPermUpdateSub =>
-      'Metadaten und Bibliothekselemente bearbeiten';
+  String get adminUsersPermUpdateSub => 'Metadaten und Bibliothekselemente bearbeiten';
 
   @override
   String get adminUsersPermDelete => 'Löschen';
@@ -3753,8 +3605,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminUsersFailedCreate => 'Benutzer konnte nicht erstellt werden';
 
   @override
-  String get adminUsersFailedUpdate =>
-      'Benutzer konnte nicht aktualisiert werden';
+  String get adminUsersFailedUpdate => 'Benutzer konnte nicht aktualisiert werden';
 
   @override
   String get adminUsersThisUser => 'diesen Benutzer';
@@ -3843,12 +3694,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Auf neue Episoden prüfen';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'Dies prüft die RSS-Feeds aller Podcasts und lädt alle gefundenen neuen Episoden herunter (sofern Auto-Download aktiviert ist).';
+  String get adminPodcastsCheckNewEpisodesContent => 'Dies prüft die RSS-Feeds aller Podcasts und lädt alle gefundenen neuen Episoden herunter (sofern Auto-Download aktiviert ist).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'RSS-Feed durchsuchen und neue Episoden herunterladen';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'RSS-Feed durchsuchen und neue Episoden herunterladen';
 
   @override
   String get adminPodcastsCheck => 'Prüfen';
@@ -3860,8 +3709,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsCheckingForNewDots => 'Suche nach neuen Episoden...';
 
   @override
-  String get adminPodcastsFailedCheckEpisodes =>
-      'Episoden konnten nicht geprüft werden';
+  String get adminPodcastsFailedCheckEpisodes => 'Episoden konnten nicht geprüft werden';
 
   @override
   String get adminPodcastsCheckFeedsTooltip => 'Feeds auf neue Episoden prüfen';
@@ -3870,8 +3718,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsNoPodcastsYet => 'Noch keine Podcasts';
 
   @override
-  String get adminPodcastsTapPlusHint =>
-      'Tippe auf +, um Sendungen zu suchen und hinzuzufügen';
+  String get adminPodcastsTapPlusHint => 'Tippe auf +, um Sendungen zu suchen und hinzuzufügen';
 
   @override
   String adminPodcastsEpisodesCount(int count) {
@@ -4022,8 +3869,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedRemoveShow =>
-      'Sendung konnte nicht entfernt werden';
+  String get adminPodcastsFailedRemoveShow => 'Sendung konnte nicht entfernt werden';
 
   @override
   String get adminPodcastsRemoveShowTooltip => 'Sendung entfernen';
@@ -4081,8 +3927,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsBrowseFeedToDownload =>
-      'Feed durchsuchen, um herunterzuladen';
+  String get adminPodcastsBrowseFeedToDownload => 'Feed durchsuchen, um herunterzuladen';
 
   @override
   String get adminPodcastsDownloadingDots => 'Wird heruntergeladen...';
@@ -4122,8 +3967,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Suche nach neuen Episoden fehlgeschlagen';
+  String get adminPodcastsFailedToCheckNew => 'Suche nach neuen Episoden fehlgeschlagen';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Prüfen & Herunterladen';
@@ -4132,24 +3976,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Podcast zuordnen';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'iTunes durchsuchen, um Cover und Metadaten zu aktualisieren';
+  String get adminPodcastsMatchPodcastSubtitle => 'iTunes durchsuchen, um Cover und Metadaten zu aktualisieren';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Neue Episoden automatisch herunterladen';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Neue Episoden automatisch herunterladen';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server lädt neue Episoden automatisch herunter';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server lädt neue Episoden automatisch herunter';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'Neue Episoden werden nicht automatisch heruntergeladen';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'Neue Episoden werden nicht automatisch heruntergeladen';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Auto-Download-Einstellung konnte nicht aktualisiert werden';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Auto-Download-Einstellung konnte nicht aktualisiert werden';
 
   @override
   String get adminPodcastsCheckSchedule => 'Prüfplan';
@@ -4225,12 +4064,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPodcastsNoResults => 'Keine Ergebnisse';
 
   @override
-  String get adminPodcastsPodcastMatched =>
-      'Podcast zugeordnet und aktualisiert';
+  String get adminPodcastsPodcastMatched => 'Podcast zugeordnet und aktualisiert';
 
   @override
-  String get adminPodcastsFailedMatch =>
-      'Podcast konnte nicht zugeordnet werden';
+  String get adminPodcastsFailedMatch => 'Podcast konnte nicht zugeordnet werden';
 
   @override
   String get episodeListEpisodeFallback => 'Episode';
@@ -4261,8 +4098,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Neue Episoden abbestellen';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Neue Episoden abbestellen';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Neue Episoden abonnieren';
@@ -4271,8 +4107,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Diesen Podcast abonnieren?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'Neue Episoden werden automatisch heruntergeladen und zu deiner Absorbing-Warteschlange hinzugefügt, sobald sie auf dem Server erscheinen.';
+  String get episodeListSubscribeContent => 'Neue Episoden werden automatisch heruntergeladen und zu deiner Absorbing-Warteschlange hinzugefügt, sobald sie auf dem Server erscheinen.';
 
   @override
   String get episodeListSubscribe => 'Abonnieren';
@@ -4284,12 +4119,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get episodeListHideFinishedEpisodes => 'Beendete Episoden ausblenden';
 
   @override
-  String get episodeListPlaysNewerToOlder =>
-      'Spielt von neueren zu älteren Episoden';
+  String get episodeListPlaysNewerToOlder => 'Spielt von neueren zu älteren Episoden';
 
   @override
-  String get episodeListPlaysOlderToNewer =>
-      'Spielt von älteren zu neueren Episoden';
+  String get episodeListPlaysOlderToNewer => 'Spielt von älteren zu neueren Episoden';
 
   @override
   String episodeListEpisodeCount(int count) {
@@ -4343,12 +4176,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Als beendet markiert - super!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'Dies setzt deinen Fortschritt für diese Episode auf 100 %.';
+  String get episodeDetailMarkAbsorbedContent => 'Dies setzt deinen Fortschritt für diese Episode auf 100 %.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'Dies löscht den gesamten Fortschritt für diese Episode und setzt sie auf den Anfang zurück. Das kann nicht rückgängig gemacht werden.';
+  String get episodeDetailResetProgressContent => 'Dies löscht den gesamten Fortschritt für diese Episode und setzt sie auf den Anfang zurück. Das kann nicht rückgängig gemacht werden.';
 
   @override
   String get episodeDetailToday => 'Heute';
@@ -4393,8 +4224,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get editMetadataUpdatedFromMatch =>
-      'Metadaten aus Zuordnung aktualisiert';
+  String get editMetadataUpdatedFromMatch => 'Metadaten aus Zuordnung aktualisiert';
 
   @override
   String editMetadataConfirmMatch(String title) {
@@ -4410,22 +4240,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Fehlende Bücher finden';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'Dies durchsucht Audible nach Büchern dieser Serie, die in deiner Bibliothek fehlen könnten.\n\nBücher werden zuerst über die ASIN abgeglichen (sofern dein Server ASINs für seine Bücher hat) und greifen dann auf den Titelabgleich zurück. Die Ergebnisse sind möglicherweise nicht ganz genau.';
+  String get seriesBooksFindMissingContent => 'Dies durchsucht Audible nach Büchern dieser Serie, die in deiner Bibliothek fehlen könnten.\n\nBücher werden zuerst über die ASIN abgeglichen (sofern dein Server ASINs für seine Bücher hat) und greifen dann auf den Titelabgleich zurück. Die Ergebnisse sind möglicherweise nicht ganz genau.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Diese Serie konnte auf Audible nicht gefunden werden';
+  String get seriesBooksCouldNotFindOnAudible => 'Diese Serie konnte auf Audible nicht gefunden werden';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'Damit wird der Beendet-Status für alle $count Bücher dieser Serie zurückgesetzt.',
-      one:
-          'Damit wird der Beendet-Status für 1 Buch dieser Serie zurückgesetzt.',
+      other: 'Damit wird der Beendet-Status für alle $count Bücher dieser Serie zurückgesetzt.',
+      one: 'Damit wird der Beendet-Status für 1 Buch dieser Serie zurückgesetzt.',
     );
     return '$_temp0';
   }
@@ -4435,8 +4261,7 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'Damit werden alle $count Bücher dieser Serie als beendet markiert.',
+      other: 'Damit werden alle $count Bücher dieser Serie als beendet markiert.',
       one: 'Damit wird 1 Buch dieser Serie als beendet markiert.',
     );
     return '$_temp0';
@@ -4554,12 +4379,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get statsScreenCouldNotLoadItem =>
-      'Element konnte nicht geladen werden';
+  String get statsScreenCouldNotLoadItem => 'Element konnte nicht geladen werden';
 
   @override
-  String get statsScreenCouldNotFindEpisode =>
-      'Episode konnte nicht gefunden werden';
+  String get statsScreenCouldNotFindEpisode => 'Episode konnte nicht gefunden werden';
 
   @override
   String statsScreenByAuthor(String author) {
@@ -4579,8 +4402,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4648,8 +4470,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$day. $month $year um $hour:$minute $ampm';
   }
 
@@ -4707,8 +4528,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get upcomingReleasesRescan => 'Erneut scannen';
 
   @override
-  String get upcomingReleasesRescanReleaseDate =>
-      'Veröffentlichungstermin erneut scannen';
+  String get upcomingReleasesRescanReleaseDate => 'Veröffentlichungstermin erneut scannen';
 
   @override
   String get upcomingReleasesRescanning => 'Wird erneut gescannt...';
@@ -4719,8 +4539,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoReleaseDateFound =>
-      'Kein Veröffentlichungstermin gefunden';
+  String get upcomingReleasesNoReleaseDateFound => 'Kein Veröffentlichungstermin gefunden';
 
   @override
   String get upcomingReleasesRescanFailed => 'Erneuter Scan fehlgeschlagen';
@@ -4764,8 +4583,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'Keine kommenden oder kürzlichen Veröffentlichungen gefunden';
+  String get upcomingReleasesNoneFound => 'Keine kommenden oder kürzlichen Veröffentlichungen gefunden';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4859,8 +4677,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audibleSeriesNoBooksFound => 'Keine Bücher auf Audible gefunden';
 
   @override
-  String get audibleSeriesFailedToLoad =>
-      'Serie konnte nicht von Audible geladen werden';
+  String get audibleSeriesFailedToLoad => 'Serie konnte nicht von Audible geladen werden';
 
   @override
   String audibleSeriesSummary(int total, int missing) {
@@ -4868,8 +4685,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total auf Audible · $missing fehlen · $upcoming kommend';
   }
 
@@ -4895,8 +4711,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audibleSeriesCompleteSeries => 'Du hast die komplette Serie!';
 
   @override
-  String get audibleSeriesNoUpcoming =>
-      'Keine kommenden Veröffentlichungen gefunden';
+  String get audibleSeriesNoUpcoming => 'Keine kommenden Veröffentlichungen gefunden';
 
   @override
   String get audibleSeriesUpcomingBadge => 'KOMMEND';
@@ -4923,12 +4738,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audibleSeriesAlreadyInUpcoming => 'Already on the upcoming page';
 
   @override
-  String get audibleSeriesCouldNotOpenAudible =>
-      'Audible konnte nicht geöffnet werden';
+  String get audibleSeriesCouldNotOpenAudible => 'Audible konnte nicht geöffnet werden';
 
   @override
-  String get audibleSeriesCouldNotOpenCalendar =>
-      'Kalender konnte nicht geöffnet werden';
+  String get audibleSeriesCouldNotOpenCalendar => 'Kalender konnte nicht geöffnet werden';
 
   @override
   String audibleSeriesCalendarDescription(String seriesName) {
@@ -4966,8 +4779,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get metadataLookupOverrideLocalDisplay =>
-      'Lokale Anzeige überschreiben';
+  String get metadataLookupOverrideLocalDisplay => 'Lokale Anzeige überschreiben';
 
   @override
   String get equalizerPresetFlat => 'Flach';
@@ -5022,8 +4834,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Kommende Veröffentlichungen';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Audible nach neuen Veröffentlichungen in deinen Serien durchsuchen';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Audible nach neuen Veröffentlichungen in deinen Serien durchsuchen';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5134,8 +4945,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'Dieser Zeitpunkt ist bereits vorbei';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'Dieser Zeitpunkt ist bereits vorbei';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Timer starten';
@@ -5221,8 +5031,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Genre-Bereich hinzufügen';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Wähle ein Genre für deinen Startbildschirm';
+  String get homeCustomizeAddGenreSubtitle => 'Wähle ein Genre für deinen Startbildschirm';
 
   @override
   String get homeSectionDoneBadge => 'Fertig';
@@ -5231,143 +5040,121 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Schnelle Lesezeichen';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Halte den Lesezeichen-Button auf einer Karte gedrückt, um sofort ein Lesezeichen an der aktuellen Position zu setzen, ohne das Lesezeichen-Menü zu öffnen.';
+  String get tipsSheetQuickBookmarksDesc => 'Halte den Lesezeichen-Button auf einer Karte gedrückt, um sofort ein Lesezeichen an der aktuellen Position zu setzen, ohne das Lesezeichen-Menü zu öffnen.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover zum Pausieren';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tippe auf das Cover einer Karte, um abzuspielen oder zu pausieren. Schalte das in den Einstellungen unter Absorbing-Karten um. Ein dezentes Pause-Symbol zeigt sich beim Abspielen, damit du weißt, dass es antippbar ist.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tippe auf das Cover einer Karte, um abzuspielen oder zu pausieren. Schalte das in den Einstellungen unter Absorbing-Karten um. Ein dezentes Pause-Symbol zeigt sich beim Abspielen, damit du weißt, dass es antippbar ist.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Vollbild-Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Wische auf einer Absorbing-Karte nach oben, um den Vollbild-Player zu öffnen. Wische nach unten, um ihn zu schließen.';
+  String get tipsSheetFullScreenPlayerDesc => 'Wische auf einer Absorbing-Karte nach oben, um den Vollbild-Player zu öffnen. Wische nach unten, um ihn zu schließen.';
 
   @override
-  String get tipsSheetQuickAddAbsorbingTitle =>
-      'Schnell zu Absorbing hinzufügen';
+  String get tipsSheetQuickAddAbsorbingTitle => 'Schnell zu Absorbing hinzufügen';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Wische in einem Listen-Sheet (Serie, Autor, Suchergebnisse) nach rechts auf einem Buch, um es sofort zur Absorbing-Warteschlange hinzuzufügen.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Wische in einem Listen-Sheet (Serie, Autor, Suchergebnisse) nach rechts auf einem Buch, um es sofort zur Absorbing-Warteschlange hinzuzufügen.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Schütteln verlängert Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'Wenn ein Sleep-Timer läuft und du dein Handy schüttelst, werden zusätzliche Minuten draufgepackt. Stelle die Menge in den Einstellungen unter Sleep-Timer ein.';
+  String get tipsSheetShakeExtendSleepDesc => 'Wenn ein Sleep-Timer läuft und du dein Handy schüttelst, werden zusätzliche Minuten draufgepackt. Stelle die Menge in den Einstellungen unter Sleep-Timer ein.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Serien-Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tippe in den Buchdetails auf den Seriennamen, um alle Bücher der Serie in Lesereihenfolge zu sehen, mit Reihenfolge-Badges auf jedem Cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tippe in den Buchdetails auf den Seriennamen, um alle Bücher der Serie in Lesereihenfolge zu sehen, mit Reihenfolge-Badges auf jedem Cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Zwischen Büchern wischen';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Wische auf dem Absorbing-Bildschirm nach links und rechts, um zwischen deinen angefangenen Büchern zu wechseln. Im manuellen Warteschlangenmodus dienen die Karten als Warteschlange, sodass das nächste Buch automatisch startet, wenn das aktuelle endet.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Wische auf dem Absorbing-Bildschirm nach links und rechts, um zwischen deinen angefangenen Büchern zu wechseln. Im manuellen Warteschlangenmodus dienen die Karten als Warteschlange, sodass das nächste Buch automatisch startet, wenn das aktuelle endet.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tippen zum Spulen';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tippe irgendwo auf den Kapitel- oder Buchfortschrittsbalken, um direkt zu dieser Stelle zu springen. Du kannst die Balken auch ziehen, um feiner zu steuern.';
+  String get tipsSheetTapToSeekDesc => 'Tippe irgendwo auf den Kapitel- oder Buchfortschrittsbalken, um direkt zu dieser Stelle zu springen. Du kannst die Balken auch ziehen, um feiner zu steuern.';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeTitle =>
-      'Geschwindigkeitsangepasste Zeit';
+  String get tipsSheetSpeedAdjustedTimeTitle => 'Geschwindigkeitsangepasste Zeit';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Restzeit und Kapitelzeiten passen sich automatisch deiner Wiedergabegeschwindigkeit an. Hörst du mit 1,5x? Die angezeigte Zeit zeigt, wie lange es tatsächlich dauert.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Restzeit und Kapitelzeiten passen sich automatisch deiner Wiedergabegeschwindigkeit an. Hörst du mit 1,5x? Die angezeigte Zeit zeigt, wie lange es tatsächlich dauert.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Wiedergabe-Verlauf';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tippe auf einer Karte auf den Verlaufs-Button, um eine Zeitleiste mit jeder Wiedergabe, Pause, Sprung und Geschwindigkeitsänderung zu sehen. Tippe auf ein Ereignis, um zu dieser Stelle zurückzuspringen.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tippe auf einer Karte auf den Verlaufs-Button, um eine Zeitleiste mit jeder Wiedergabe, Pause, Sprung und Geschwindigkeitsänderung zu sehen. Tippe auf ein Ereignis, um zu dieser Stelle zurückzuspringen.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Zurückspulen';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'Wenn du nach einer Pause weiterhörst, spult Absorb automatisch ein paar Sekunden zurück, damit du den Anschluss nicht verlierst. Wie weit zurückgespult wird, hängt davon ab, wie lange du weg warst. In den Einstellungen anpassbar.';
+  String get tipsSheetAutoRewindDesc => 'Wenn du nach einer Pause weiterhörst, spult Absorb automatisch ein paar Sekunden zurück, damit du den Anschluss nicht verlierst. Wie weit zurückgespult wird, hängt davon ab, wie lange du weg warst. In den Einstellungen anpassbar.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Serien-Warteschlangenmodus';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'Wenn du ein Buch beendest, das Teil einer Serie ist, kann Absorb automatisch das nächste Buch abspielen. Stelle den Warteschlangenmodus in den Einstellungen auf \"Serie\".';
+  String get tipsSheetSeriesQueueModeDesc => 'Wenn du ein Buch beendest, das Teil einer Serie ist, kann Absorb automatisch das nächste Buch abspielen. Stelle den Warteschlangenmodus in den Einstellungen auf \"Serie\".';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline-Modus';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tippe auf dem Absorbing-Bildschirm auf den Flugzeug-Button, um in den Offline-Modus zu wechseln. Das stoppt die Synchronisierung, spart Daten und zeigt nur deine heruntergeladenen Bücher. Ideal für Flüge oder schlechten Empfang.';
+  String get tipsSheetOfflineModeDesc => 'Tippe auf dem Absorbing-Bildschirm auf den Flugzeug-Button, um in den Offline-Modus zu wechseln. Das stoppt die Synchronisierung, spart Daten und zeigt nur deine heruntergeladenen Bücher. Ideal für Flüge oder schlechten Empfang.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Kommende Veröffentlichungen';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Equalizer pro Buch';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Jedes Buch merkt sich seine eigenen EQ-Einstellungen. Stell den EQ einmal für ein Sci-Fi-Epos ein und beim nächsten Mal klingt es genauso.';
+  String get tipsSheetPerBookEqDesc => 'Jedes Buch merkt sich seine eigenen EQ-Einstellungen. Stell den EQ einmal für ein Sci-Fi-Epos ein und beim nächsten Mal klingt es genauso.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Geschwindigkeit pro Buch';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Die Wiedergabegeschwindigkeit wird pro Buch gespeichert. Sachbücher mit 1,5x und dramatische Romane mit 1,0x hören - ohne es jedes Mal neu einstellen zu müssen.';
+  String get tipsSheetPerBookSpeedDesc => 'Die Wiedergabegeschwindigkeit wird pro Buch gespeichert. Sachbücher mit 1,5x und dramatische Romane mit 1,0x hören - ohne es jedes Mal neu einstellen zu müssen.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto-Sleep-Zeitfenster';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Wähle die Stunden, in denen du normalerweise einschläfst, und der Sleep-Timer startet automatisch, wenn du in diesem Fenster zu hören beginnst.';
+  String get tipsSheetAutoSleepWindowDesc => 'Wähle die Stunden, in denen du normalerweise einschläfst, und der Sleep-Timer startet automatisch, wenn du in diesem Fenster zu hören beginnst.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep-Fade und Klangzeichen';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'Wenn der Sleep-Timer endet, wird das Audio langsam ausgeblendet und ein optionales Klangzeichen ertönt, damit nicht mitten im Satz abgeschnitten wird.';
+  String get tipsSheetSleepFadeChimeDesc => 'Wenn der Sleep-Timer endet, wird das Audio langsam ausgeblendet und ein optionales Klangzeichen ertönt, damit nicht mitten im Satz abgeschnitten wird.';
 
   @override
   String get tipsSheetCarModeTitle => 'Auto-Modus';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tippe auf das Auto-Symbol, um in den Modus mit großen Buttons zu wechseln, der für sicherere Bedienung beim Fahren gedacht ist.';
+  String get tipsSheetCarModeDesc => 'Tippe auf das Auto-Symbol, um in den Modus mit großen Buttons zu wechseln, der für sicherere Bedienung beim Fahren gedacht ist.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible-Serien-Suche';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unbekannter Titel';
@@ -5506,8 +5293,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cardEdgeProgressHalfSpeed => 'Halbe Geschwindigkeit';
 
   @override
-  String get authSessionExpired =>
-      'Sitzung abgelaufen. Bitte melde dich erneut an.';
+  String get authSessionExpired => 'Sitzung abgelaufen. Bitte melde dich erneut an.';
 
   @override
   String authCannotReachServer(String url) {
@@ -5515,22 +5301,19 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get authInvalidUsernameOrPassword =>
-      'Ungültiger Benutzername oder Passwort';
+  String get authInvalidUsernameOrPassword => 'Ungültiger Benutzername oder Passwort';
 
   @override
   String get authInvalidApiKey => 'Ungültiger API-Schlüssel';
 
   @override
-  String get authLoginFailedDetail =>
-      'Anmeldung fehlgeschlagen - prüfe Serveradresse und Zugangsdaten';
+  String get authLoginFailedDetail => 'Anmeldung fehlgeschlagen - prüfe Serveradresse und Zugangsdaten';
 
   @override
   String get authUnexpectedServerResponse => 'Unerwartete Server-Antwort';
 
   @override
-  String get authSsoUnexpectedResponse =>
-      'SSO hat eine unerwartete Antwort zurückgegeben';
+  String get authSsoUnexpectedResponse => 'SSO hat eine unerwartete Antwort zurückgegeben';
 
   @override
   String get authSwitchedToLocalServer => 'Zu lokalem Server gewechselt';
@@ -5589,15 +5372,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download-Fortschritt';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Zeigt den Fortschritt während Hörbuch-Downloads';
+  String get downloadNotifProgressChannelDesc => 'Zeigt den Fortschritt während Hörbuch-Downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download-Benachrichtigungen';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Benachrichtigungen, wenn Downloads beendet werden oder fehlschlagen';
+  String get downloadNotifAlertChannelDesc => 'Benachrichtigungen, wenn Downloads beendet werden oder fehlschlagen';
 
   @override
   String get downloadNotifDownloadingTitle => 'Wird heruntergeladen…';
@@ -5633,23 +5414,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadNotifFailedTitle => 'Download fehlgeschlagen';
 
   @override
-  String get upcomingNotifChannelName =>
-      'Suche nach kommenden Veröffentlichungen';
+  String get upcomingNotifChannelName => 'Suche nach kommenden Veröffentlichungen';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Zeigt den Fortschritt beim Scannen nach kommenden Veröffentlichungen';
+  String get upcomingNotifChannelDesc => 'Zeigt den Fortschritt beim Scannen nach kommenden Veröffentlichungen';
 
   @override
-  String get upcomingNotifScanTitle =>
-      'Suche nach kommenden Veröffentlichungen';
+  String get upcomingNotifScanTitle => 'Suche nach kommenden Veröffentlichungen';
 
   @override
   String get upcomingNotifStartingScan => 'Suche wird gestartet…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Prüfe $seriesName… ($current/$total)';
   }
 
@@ -5689,23 +5466,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showTipsAgain => 'Tipps wieder anzeigen';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bringe ausgeblendete Funktions-Tipps zurück';
+  String get showTipsAgainSubtitle => 'Bringe ausgeblendete Funktions-Tipps zurück';
 
   @override
   String get tipsRestored => 'Tipps wiederhergestellt';
 
   @override
-  String get resetSpeedPresets =>
-      'Geschwindigkeits-Voreinstellungen zurücksetzen';
+  String get resetSpeedPresets => 'Geschwindigkeits-Voreinstellungen zurücksetzen';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Standard-Wiedergabegeschwindigkeiten wiederherstellen';
+  String get resetSpeedPresetsSubtitle => 'Standard-Wiedergabegeschwindigkeiten wiederherstellen';
 
   @override
-  String get speedPresetsReset =>
-      'Geschwindigkeits-Voreinstellungen zurückgesetzt';
+  String get speedPresetsReset => 'Geschwindigkeits-Voreinstellungen zurückgesetzt';
 
   @override
   String get editAuthor => 'Autor bearbeiten';
@@ -5723,15 +5496,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authorRemoveImageTitle => 'Autorenbild entfernen?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'Dadurch wird das Bild auf dem Server gelöscht.';
+  String get authorRemoveImageConfirm => 'Dadurch wird das Bild auf dem Server gelöscht.';
 
   @override
   String get authorImageRemoved => 'Bild entfernt';
 
   @override
-  String get authorImageFailed =>
-      'Das Autorenbild konnte nicht aktualisiert werden';
+  String get authorImageFailed => 'Das Autorenbild konnte nicht aktualisiert werden';
 
   @override
   String get authorUpdated => 'Autor aktualisiert';
@@ -5751,8 +5522,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5779,8 +5549,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5855,8 +5624,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5898,8 +5666,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterShiftBySeconds => 'Verschieben um (Sekunden)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5943,8 +5710,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5969,12 +5735,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5986,8 +5750,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get coverSearchTitle => 'Nach einem Cover suchen';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -6008,23 +5771,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -6046,8 +5805,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -6055,8 +5813,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6147,8 +5904,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6187,8 +5943,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6281,8 +6036,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6423,8 +6177,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6546,6 +6299,5 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -120,7 +120,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsEl extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsEl extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsEl extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsEl extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsEl extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsEl extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsEl extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -120,8 +120,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsEl extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsEl extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsEl extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsEl extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsEl extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -120,8 +120,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsEn extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsEn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -120,7 +120,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsEn extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsEn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -120,8 +120,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsEs extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsEs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -120,7 +120,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsEs extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsEs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsEs extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -18,8 +18,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get offline => 'Déconnecté';
 
   @override
-  String get stillOffline =>
-      'Toujours déconnecté. Touchez pour essayer encore.';
+  String get stillOffline => 'Toujours déconnecté. Touchez pour essayer encore.';
 
   @override
   String get retry => 'Réessayer';
@@ -121,8 +120,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Votre bibliothèque est vide';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Personnaliser l\'accueil';
@@ -146,8 +144,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginServerHelper => 'IP + port (ex : 192.168.1.5:13378)';
 
   @override
-  String get loginCouldNotReachServer =>
-      'Impossible de se connecter au serveur';
+  String get loginCouldNotReachServer => 'Impossible de se connecter au serveur';
 
   @override
   String get loginAdvanced => 'Avancé';
@@ -156,8 +153,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Entêtes HTTP personnalisés';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -172,15 +168,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Certificat auto-signé';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'Clé API';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -228,12 +222,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -242,8 +234,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -262,8 +253,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Restaurer depuis une sauvegarde';
@@ -280,8 +270,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restaurer';
@@ -292,8 +281,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Paramètres restaurés';
@@ -310,8 +298,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libraryTitle => 'Bibliothèque';
 
   @override
-  String get librarySearchBooksHint =>
-      'Rechercher par livres, séries, auteurs, narrateurs ...';
+  String get librarySearchBooksHint => 'Rechercher par livres, séries, auteurs, narrateurs ...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -509,20 +496,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -578,8 +561,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -910,8 +892,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -932,12 +913,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -952,8 +931,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -962,15 +940,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1009,8 +985,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1022,8 +997,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1032,8 +1006,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1042,8 +1015,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1052,8 +1024,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1062,12 +1033,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1082,16 +1051,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1103,15 +1069,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1129,8 +1093,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1144,8 +1107,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1200,8 +1162,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1210,45 +1171,37 @@ class AppLocalizationsFr extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1274,8 +1227,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1286,8 +1238,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1356,23 +1307,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1383,8 +1330,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1441,12 +1387,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1458,8 +1402,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1468,8 +1411,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1478,12 +1420,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1514,15 +1454,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1551,8 +1489,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1564,8 +1501,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1574,8 +1510,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1605,19 +1540,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1646,8 +1578,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1656,8 +1587,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1666,8 +1596,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1676,23 +1605,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1704,16 +1629,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1735,8 +1657,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1763,8 +1684,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1787,8 +1707,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1823,8 +1742,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1875,15 +1793,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1892,19 +1808,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1922,10 +1835,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2027,8 +1938,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2046,8 +1956,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2067,23 +1976,19 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2107,8 +2012,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2134,8 +2038,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2176,8 +2079,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2204,8 +2106,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2214,8 +2115,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2242,8 +2142,29 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2444,8 +2365,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2480,36 +2400,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2518,8 +2433,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2548,8 +2462,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2632,8 +2545,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2671,8 +2583,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2699,8 +2610,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2850,15 +2760,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2867,8 +2775,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2921,12 +2828,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2938,15 +2843,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3036,8 +2939,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3049,8 +2951,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3062,15 +2963,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3088,16 +2987,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3108,8 +3004,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3163,8 +3058,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3183,8 +3077,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3201,8 +3094,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3214,15 +3106,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3263,8 +3153,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3418,8 +3307,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3498,8 +3386,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3507,8 +3394,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3808,12 +3694,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4083,8 +3967,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4093,24 +3976,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4220,8 +4098,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4230,8 +4107,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4300,12 +4176,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4366,20 +4240,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4531,8 +4402,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4600,8 +4470,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4714,8 +4583,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4817,8 +4685,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4967,8 +4834,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5079,8 +4945,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5166,8 +5031,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5176,141 +5040,121 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5463,8 +5307,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5529,15 +5372,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5576,8 +5417,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5586,8 +5426,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5627,8 +5466,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5637,8 +5475,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5659,8 +5496,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5686,8 +5522,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5714,8 +5549,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5790,8 +5624,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5833,8 +5666,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5878,8 +5710,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5904,12 +5735,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5921,8 +5750,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5943,23 +5771,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5981,8 +5805,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5990,8 +5813,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6082,8 +5904,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6122,8 +5943,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6216,8 +6036,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6358,8 +6177,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6481,6 +6299,5 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2222,6 +2222,44 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2056,6 +2056,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -18,7 +18,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get offline => 'Déconnecté';
 
   @override
-  String get stillOffline => 'Toujours déconnecté. Touchez pour essayer encore.';
+  String get stillOffline =>
+      'Toujours déconnecté. Touchez pour essayer encore.';
 
   @override
   String get retry => 'Réessayer';
@@ -120,7 +121,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Votre bibliothèque est vide';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Personnaliser l\'accueil';
@@ -144,7 +146,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginServerHelper => 'IP + port (ex : 192.168.1.5:13378)';
 
   @override
-  String get loginCouldNotReachServer => 'Impossible de se connecter au serveur';
+  String get loginCouldNotReachServer =>
+      'Impossible de se connecter au serveur';
 
   @override
   String get loginAdvanced => 'Avancé';
@@ -153,7 +156,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Entêtes HTTP personnalisés';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +172,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Certificat auto-signé';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'Clé API';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +228,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +242,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +262,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Restaurer depuis une sauvegarde';
@@ -270,7 +280,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restaurer';
@@ -281,7 +292,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Paramètres restaurés';
@@ -298,7 +310,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libraryTitle => 'Bibliothèque';
 
   @override
-  String get librarySearchBooksHint => 'Rechercher par livres, séries, auteurs, narrateurs ...';
+  String get librarySearchBooksHint =>
+      'Rechercher par livres, séries, auteurs, narrateurs ...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +509,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +578,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +910,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +932,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +952,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +962,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1009,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1022,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1032,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1042,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1052,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1062,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1082,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1103,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1129,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1144,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1200,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1210,45 @@ class AppLocalizationsFr extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1274,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1286,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1356,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1383,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1441,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1458,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1468,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1478,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1514,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1551,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1564,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1574,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1605,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1646,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1656,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1666,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1676,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1704,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1735,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1763,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1787,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1823,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1875,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1892,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1922,10 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2027,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2046,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2067,23 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2107,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2134,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2176,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2204,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2214,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2242,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2467,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2503,36 @@ class AppLocalizationsFr extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2541,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2571,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2655,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2694,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2722,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2873,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2890,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2944,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2961,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3059,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3072,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3085,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3111,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3131,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3186,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3206,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3224,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3237,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3286,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3441,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3521,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3530,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3831,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4106,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4116,24 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4243,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4253,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4323,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4389,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4554,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4623,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4737,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4840,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4990,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5102,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5189,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5199,141 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5486,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5552,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5599,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5609,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5650,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5660,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5682,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5709,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5737,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5813,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5856,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5901,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5927,12 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5944,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5966,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6004,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6013,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6105,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6145,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6239,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6381,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6504,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -120,8 +120,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsIt extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsIt extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -120,7 +120,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsIt extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsIt extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsIt extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsIt extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsIt extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -120,7 +120,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsJa extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsJa extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsJa extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsJa extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsJa extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsJa extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsJa extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -120,8 +120,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsJa extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsJa extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsJa extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_no.dart
+++ b/lib/l10n/app_localizations_no.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_no.dart
+++ b/lib/l10n/app_localizations_no.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_no.dart
+++ b/lib/l10n/app_localizations_no.dart
@@ -120,7 +120,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsNo extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsNo extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsNo extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsNo extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsNo extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsNo extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsNo extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsNo extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsNo extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsNo extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_no.dart
+++ b/lib/l10n/app_localizations_no.dart
@@ -120,8 +120,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsNo extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsNo extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsNo extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsNo extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsNo extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -120,7 +120,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsPt extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsPt extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsPt extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsPt extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsPt extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsPt extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsPt extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -120,8 +120,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsPt extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsPt extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -120,7 +120,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +154,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +170,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +226,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +240,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +260,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +278,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +290,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +308,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +507,20 @@ class AppLocalizationsRo extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +576,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +908,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite =>
+      'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +930,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +950,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +960,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -985,7 +1007,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1020,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1030,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1040,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1050,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1060,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1080,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1101,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1127,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1142,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1198,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1208,45 @@ class AppLocalizationsRo extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1272,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1284,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1354,23 @@ class AppLocalizationsRo extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1381,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1439,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1456,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1466,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1476,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1512,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1549,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1562,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1572,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1603,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1644,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1654,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1664,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1674,23 @@ class AppLocalizationsRo extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1702,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1657,7 +1733,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1761,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1785,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1821,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1793,13 +1873,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1890,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1920,10 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2025,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2044,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2065,23 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2105,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2132,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2174,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2202,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2212,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2240,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2465,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2501,36 @@ class AppLocalizationsRo extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2539,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2569,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2653,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2692,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2720,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2871,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2888,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2942,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2959,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3057,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3070,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3083,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3109,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3129,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3184,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3204,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3222,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3235,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3284,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3439,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3519,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3528,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3829,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4104,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4114,24 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4241,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4251,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4321,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4387,20 @@ class AppLocalizationsRo extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4552,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4621,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4735,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4838,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4988,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5100,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5187,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5197,141 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5484,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5550,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5597,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5607,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5648,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5658,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5680,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5707,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5735,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5811,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5854,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5899,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5925,12 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5942,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5964,23 @@ class AppLocalizationsRo extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6002,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6011,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6103,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6143,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6237,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6379,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6502,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2054,6 +2054,17 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2220,6 +2220,44 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -120,8 +120,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Your library is empty';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -154,8 +153,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -170,15 +168,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -226,12 +222,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -240,8 +234,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -260,8 +253,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -278,8 +270,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -290,8 +281,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -308,8 +298,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -507,20 +496,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -576,8 +561,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -908,8 +892,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get languageSystemDefault => 'System default';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Want to help translate Absorb into your language?';
+  String get languageHelpTranslateInvite => 'Want to help translate Absorb into your language?';
 
   @override
   String get themeLabel => 'Theme';
@@ -930,12 +913,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -950,8 +931,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -960,15 +940,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1007,8 +985,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1020,8 +997,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1030,8 +1006,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1040,8 +1015,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1050,8 +1024,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1060,12 +1033,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1080,16 +1051,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1101,15 +1069,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1127,8 +1093,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1142,8 +1107,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1198,8 +1162,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1208,45 +1171,37 @@ class AppLocalizationsRo extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1272,8 +1227,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1284,8 +1238,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1354,23 +1307,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1381,8 +1330,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1439,12 +1387,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1456,8 +1402,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1466,8 +1411,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1476,12 +1420,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1512,15 +1454,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1549,8 +1489,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1562,8 +1501,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1572,8 +1510,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1603,19 +1540,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1644,8 +1578,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1654,8 +1587,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1664,8 +1596,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1674,23 +1605,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1702,16 +1629,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Support the Dev';
@@ -1733,8 +1657,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1761,8 +1684,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1785,8 +1707,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1821,8 +1742,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Sign Out';
@@ -1873,15 +1793,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1890,19 +1808,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1920,10 +1835,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2025,8 +1938,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2044,8 +1956,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2065,23 +1976,19 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2105,8 +2012,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2132,8 +2038,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2174,8 +2079,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2202,8 +2106,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2212,8 +2115,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2240,8 +2142,29 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2442,8 +2365,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2478,36 +2400,31 @@ class AppLocalizationsRo extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2516,8 +2433,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2546,8 +2462,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2630,8 +2545,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2669,8 +2583,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2697,8 +2610,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2848,15 +2760,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2865,8 +2775,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2919,12 +2828,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2936,15 +2843,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3034,8 +2939,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3047,8 +2951,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3060,15 +2963,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3086,16 +2987,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3106,8 +3004,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3161,8 +3058,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3181,8 +3077,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3199,8 +3094,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3212,15 +3106,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3261,8 +3153,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3416,8 +3307,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3496,8 +3386,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3505,8 +3394,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3806,12 +3694,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4081,8 +3967,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4091,24 +3976,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4218,8 +4098,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4228,8 +4107,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4298,12 +4176,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4364,20 +4240,17 @@ class AppLocalizationsRo extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4529,8 +4402,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4598,8 +4470,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4712,8 +4583,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4815,8 +4685,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4965,8 +4834,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5077,8 +4945,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5164,8 +5031,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5174,141 +5040,121 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5461,8 +5307,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5527,15 +5372,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5574,8 +5417,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5584,8 +5426,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5625,8 +5466,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5635,8 +5475,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5657,8 +5496,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5684,8 +5522,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5712,8 +5549,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5788,8 +5624,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5831,8 +5666,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5876,8 +5710,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5902,12 +5735,10 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5919,8 +5750,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5941,23 +5771,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5979,8 +5805,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5988,8 +5813,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6080,8 +5904,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6120,8 +5943,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6214,8 +6036,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6356,8 +6177,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6479,6 +6299,5 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2057,6 +2057,17 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminRmabAskAdmin => 'Get a login URL from your server admin';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -18,8 +18,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get offline => 'Offline';
 
   @override
-  String get stillOffline =>
-      'Не удается подключиться. Нажмите, чтобы попробовать еще раз.';
+  String get stillOffline => 'Не удается подключиться. Нажмите, чтобы попробовать еще раз.';
 
   @override
   String get retry => 'Retry';
@@ -121,8 +120,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Ваша библиотека пуста';
 
   @override
-  String get downloadBooksWhileOnline =>
-      'Download books while online to listen offline';
+  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -155,8 +153,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription =>
-      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -171,15 +168,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates =>
-      'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription =>
-      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -227,12 +222,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -241,8 +234,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -261,8 +253,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed =>
-      'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -279,8 +270,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts =>
-      'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -291,8 +281,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired =>
-      'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -309,8 +298,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint =>
-      'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -508,20 +496,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen =>
-      'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen =>
-      'Download books to listen offline';
+  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows =>
-      'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary =>
-      'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -577,8 +561,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent =>
-      'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -909,8 +892,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get languageSystemDefault => 'По умолчанию системы';
 
   @override
-  String get languageHelpTranslateInvite =>
-      'Хотите помочь перевести Absorb на ваш язык?';
+  String get languageHelpTranslateInvite => 'Хотите помочь перевести Absorb на ваш язык?';
 
   @override
   String get themeLabel => 'Theme';
@@ -931,12 +913,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription =>
-      'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription =>
-      'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -951,8 +931,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -961,15 +940,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -978,8 +955,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get startScreenLabel => 'Начальный экран';
 
   @override
-  String get startScreenSubtitle =>
-      'Какая вкладка открывается при запуске приложения';
+  String get startScreenSubtitle => 'Какая вкладка открывается при запуске приложения';
 
   @override
   String get startScreenHome => 'Главная';
@@ -1000,8 +976,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get disablePageFadeOnSubtitle => 'Страницы переключаются мгновенно';
 
   @override
-  String get disablePageFadeOffSubtitle =>
-      'Страницы затухают при смене вкладок';
+  String get disablePageFadeOffSubtitle => 'Страницы затухают при смене вкладок';
 
   @override
   String get rectangleBookCovers => 'Rectangle book covers';
@@ -1010,8 +985,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle =>
-      'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -1023,8 +997,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle =>
-      'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1033,8 +1006,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle =>
-      'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1043,8 +1015,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle =>
-      'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1053,8 +1024,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle =>
-      'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1063,12 +1033,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle =>
-      'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1083,16 +1051,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle =>
-      'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle =>
-      'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1104,15 +1069,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc =>
-      'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc =>
-      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1130,8 +1093,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1145,8 +1107,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1201,8 +1162,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle =>
-      'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1211,45 +1171,37 @@ class AppLocalizationsRu extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification =>
-      'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle =>
-      'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1275,8 +1227,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription =>
-      'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1287,8 +1238,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle =>
-      'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1357,23 +1307,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle =>
-      'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle =>
-      'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle =>
-      'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle =>
-      'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1384,8 +1330,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle =>
-      'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1442,12 +1387,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle =>
-      'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1459,8 +1402,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle =>
-      'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1469,8 +1411,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent =>
-      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1479,12 +1420,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle =>
-      'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1515,15 +1454,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent =>
-      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle =>
-      'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1552,8 +1489,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle =>
-      'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1565,8 +1501,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle =>
-      'For download progress and playback controls';
+  String get notificationsSubtitle => 'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1575,8 +1510,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle =>
-      'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1606,19 +1540,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle =>
-      'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar =>
-      'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar =>
-      'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1647,8 +1578,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent =>
-      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1657,8 +1587,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle =>
-      'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1667,8 +1596,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar =>
-      'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1677,23 +1605,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle =>
-      'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle =>
-      'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent =>
-      'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1705,16 +1629,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle =>
-      'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle =>
-      'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Поддержать разработчика';
@@ -1736,8 +1657,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle =>
-      'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1764,8 +1684,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent =>
-      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1788,8 +1707,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent =>
-      'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1824,8 +1742,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent =>
-      'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Выйти';
@@ -1876,15 +1793,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle =>
-      'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning =>
-      'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1893,19 +1808,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied =>
-      'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired =>
-      'Storage permission is required for custom download locations';
+  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder =>
-      'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1923,10 +1835,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2028,8 +1938,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp =>
-      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -2047,8 +1956,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed =>
-      'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -2068,23 +1976,19 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2108,8 +2012,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2135,8 +2038,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2177,8 +2079,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2205,8 +2106,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2215,8 +2115,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2243,8 +2142,29 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2445,8 +2365,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2481,36 +2400,31 @@ class AppLocalizationsRu extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent =>
-      'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection =>
-      'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent =>
-      'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt =>
-      'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent =>
-      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2519,8 +2433,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent =>
-      'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2549,8 +2462,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint =>
-      'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2633,8 +2545,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent =>
-      'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2672,8 +2583,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent =>
-      'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2700,8 +2610,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound =>
-      'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2851,15 +2760,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent =>
-      'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2868,8 +2775,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent =>
-      'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2922,12 +2828,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro =>
-      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet =>
-      'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2939,15 +2843,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody =>
-      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -3037,8 +2939,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -3050,8 +2951,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -3063,15 +2963,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3089,16 +2987,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3109,8 +3004,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3164,8 +3058,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3184,8 +3077,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3202,8 +3094,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3215,15 +3106,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3264,8 +3153,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3419,8 +3307,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3499,8 +3386,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3508,8 +3394,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3809,12 +3694,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4084,8 +3967,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4094,24 +3976,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4221,8 +4098,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4231,8 +4107,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4301,12 +4176,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4367,20 +4240,17 @@ class AppLocalizationsRu extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4532,8 +4402,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4601,8 +4470,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4715,8 +4583,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4818,8 +4685,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4968,8 +4834,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5080,8 +4945,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed =>
-      'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5167,8 +5031,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5177,141 +5040,121 @@ class AppLocalizationsRu extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5464,8 +5307,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5530,15 +5372,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5577,8 +5417,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5587,8 +5426,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5628,8 +5466,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle =>
-      'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5638,8 +5475,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle =>
-      'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5660,8 +5496,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5687,8 +5522,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5715,8 +5549,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5791,8 +5624,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5834,8 +5666,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5879,8 +5710,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5905,12 +5735,10 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5922,8 +5750,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5944,23 +5771,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5982,8 +5805,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5991,8 +5813,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6083,8 +5904,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6123,8 +5943,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6217,8 +6036,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6359,8 +6177,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6482,6 +6299,5 @@ class AppLocalizationsRu extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2223,6 +2223,44 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -18,7 +18,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get offline => 'Offline';
 
   @override
-  String get stillOffline => 'Не удается подключиться. Нажмите, чтобы попробовать еще раз.';
+  String get stillOffline =>
+      'Не удается подключиться. Нажмите, чтобы попробовать еще раз.';
 
   @override
   String get retry => 'Retry';
@@ -120,7 +121,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get yourLibraryIsEmpty => 'Ваша библиотека пуста';
 
   @override
-  String get downloadBooksWhileOnline => 'Download books while online to listen offline';
+  String get downloadBooksWhileOnline =>
+      'Download books while online to listen offline';
 
   @override
   String get customizeHome => 'Customize Home';
@@ -153,7 +155,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get loginCustomHttpHeaders => 'Custom HTTP Headers';
 
   @override
-  String get loginCustomHeadersDescription => 'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
+  String get loginCustomHeadersDescription =>
+      'For Cloudflare tunnels or reverse proxies that require extra headers. Add headers before entering your server URL.';
 
   @override
   String get loginHeaderName => 'Header name';
@@ -168,13 +171,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get loginSelfSignedCertificates => 'Self-signed Certificates';
 
   @override
-  String get loginTrustAllCertificates => 'Trust all certificates (for self-signed / custom CA setups)';
+  String get loginTrustAllCertificates =>
+      'Trust all certificates (for self-signed / custom CA setups)';
 
   @override
   String get loginApiKey => 'API Key';
 
   @override
-  String get loginApiKeyDescription => 'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
+  String get loginApiKeyDescription =>
+      'Use an admin-generated API key instead of username/password. Useful when token refresh fails for your account.';
 
   @override
   String get loginWaitingForSso => 'Waiting for SSO...';
@@ -222,10 +227,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +241,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -253,7 +261,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get loginSsoFailed => 'SSO login failed or was cancelled';
 
   @override
-  String get loginSsoAuthFailed => 'SSO authentication failed. Please try again.';
+  String get loginSsoAuthFailed =>
+      'SSO authentication failed. Please try again.';
 
   @override
   String get loginRestoreFromBackup => 'Import';
@@ -270,7 +279,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get loginRestoreBackupNoAccounts => 'This will restore all settings. No accounts were included in this backup.';
+  String get loginRestoreBackupNoAccounts =>
+      'This will restore all settings. No accounts were included in this backup.';
 
   @override
   String get loginRestore => 'Restore';
@@ -281,7 +291,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get loginSessionExpired => 'Settings restored. Session expired - sign in to continue.';
+  String get loginSessionExpired =>
+      'Settings restored. Session expired - sign in to continue.';
 
   @override
   String get loginSettingsRestored => 'Settings restored';
@@ -298,7 +309,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get libraryTitle => 'Library';
 
   @override
-  String get librarySearchBooksHint => 'Search books, series, authors, narrators...';
+  String get librarySearchBooksHint =>
+      'Search books, series, authors, narrators...';
 
   @override
   String get librarySearchShowsHint => 'Search shows and episodes...';
@@ -496,16 +508,20 @@ class AppLocalizationsRu extends AppLocalizations {
   String get absorbingNothingAbsorbingYet => 'Nothing absorbing yet';
 
   @override
-  String get absorbingDownloadEpisodesToListen => 'Download episodes to listen offline';
+  String get absorbingDownloadEpisodesToListen =>
+      'Download episodes to listen offline';
 
   @override
-  String get absorbingDownloadBooksToListen => 'Download books to listen offline';
+  String get absorbingDownloadBooksToListen =>
+      'Download books to listen offline';
 
   @override
-  String get absorbingStartEpisodeFromShows => 'Start an episode from the Shows tab';
+  String get absorbingStartEpisodeFromShows =>
+      'Start an episode from the Shows tab';
 
   @override
-  String get absorbingStartBookFromLibrary => 'Start a book from the Library tab';
+  String get absorbingStartBookFromLibrary =>
+      'Start a book from the Library tab';
 
   @override
   String get carModeTitle => 'Car Mode';
@@ -561,7 +577,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get downloadsDeleteContent => 'Downloaded files will be removed from this device.';
+  String get downloadsDeleteContent =>
+      'Downloaded files will be removed from this device.';
 
   @override
   String downloadsDeletedCount(int count) {
@@ -892,7 +909,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get languageSystemDefault => 'По умолчанию системы';
 
   @override
-  String get languageHelpTranslateInvite => 'Хотите помочь перевести Absorb на ваш язык?';
+  String get languageHelpTranslateInvite =>
+      'Хотите помочь перевести Absorb на ваш язык?';
 
   @override
   String get themeLabel => 'Theme';
@@ -913,10 +931,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get colorSourceLabel => 'Color source';
 
   @override
-  String get colorSourceCoverDescription => 'App colors follow the currently playing book cover';
+  String get colorSourceCoverDescription =>
+      'App colors follow the currently playing book cover';
 
   @override
-  String get colorSourceWallpaperDescription => 'App colors follow your system wallpaper';
+  String get colorSourceWallpaperDescription =>
+      'App colors follow your system wallpaper';
 
   @override
   String get colorSourceWallpaper => 'Wallpaper';
@@ -931,7 +951,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +961,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -955,7 +978,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get startScreenLabel => 'Начальный экран';
 
   @override
-  String get startScreenSubtitle => 'Какая вкладка открывается при запуске приложения';
+  String get startScreenSubtitle =>
+      'Какая вкладка открывается при запуске приложения';
 
   @override
   String get startScreenHome => 'Главная';
@@ -976,7 +1000,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get disablePageFadeOnSubtitle => 'Страницы переключаются мгновенно';
 
   @override
-  String get disablePageFadeOffSubtitle => 'Страницы затухают при смене вкладок';
+  String get disablePageFadeOffSubtitle =>
+      'Страницы затухают при смене вкладок';
 
   @override
   String get rectangleBookCovers => 'Rectangle book covers';
@@ -985,7 +1010,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get progressTextSize => 'Progress text size';
 
   @override
-  String get rectangleBookCoversOnSubtitle => 'Covers display in 2:3 book proportion';
+  String get rectangleBookCoversOnSubtitle =>
+      'Covers display in 2:3 book proportion';
 
   @override
   String get rectangleBookCoversOffSubtitle => 'Covers are square';
@@ -997,7 +1023,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get fullScreenPlayer => 'Full screen player';
 
   @override
-  String get fullScreenPlayerOnSubtitle => 'On - books open in full screen when played';
+  String get fullScreenPlayerOnSubtitle =>
+      'On - books open in full screen when played';
 
   @override
   String get fullScreenPlayerOffSubtitle => 'Off - play within card view';
@@ -1006,7 +1033,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get fullBookScrubber => 'Full book scrubber';
 
   @override
-  String get fullBookScrubberOnSubtitle => 'On - seekable slider across entire book';
+  String get fullBookScrubberOnSubtitle =>
+      'On - seekable slider across entire book';
 
   @override
   String get fullBookScrubberOffSubtitle => 'Off - progress bar only';
@@ -1015,7 +1043,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get speedAdjustedTime => 'Speed-adjusted time';
 
   @override
-  String get speedAdjustedTimeOnSubtitle => 'On - remaining time reflects playback speed';
+  String get speedAdjustedTimeOnSubtitle =>
+      'On - remaining time reflects playback speed';
 
   @override
   String get speedAdjustedTimeOffSubtitle => 'Off - showing raw audio duration';
@@ -1024,7 +1053,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get buttonLayout => 'Button layout';
 
   @override
-  String get buttonLayoutSubtitle => 'How action buttons are arranged on the card';
+  String get buttonLayoutSubtitle =>
+      'How action buttons are arranged on the card';
 
   @override
   String get whenAbsorbed => 'When absorbed';
@@ -1033,10 +1063,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get whenAbsorbedInfoTitle => 'When Absorbed';
 
   @override
-  String get whenAbsorbedInfoContent => 'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
+  String get whenAbsorbedInfoContent =>
+      'Controls what happens to an absorbing card when you finish a book or episode.\n\nFinished cards are automatically removed from your Absorbing screen.';
 
   @override
-  String get whenAbsorbedSubtitle => 'What happens to the absorbing card when a book or episode finishes';
+  String get whenAbsorbedSubtitle =>
+      'What happens to the absorbing card when a book or episode finishes';
 
   @override
   String get whenAbsorbedShowOverlay => 'Show Overlay';
@@ -1051,13 +1083,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mergeLibrariesInfoTitle => 'Unified Absorbing Page';
 
   @override
-  String get mergeLibrariesInfoContent => 'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
+  String get mergeLibrariesInfoContent =>
+      'When enabled, the Absorbing screen shows all your in-progress books and podcasts from every library in a single view. When disabled, only items from the library you currently have selected are shown.';
 
   @override
-  String get mergeLibrariesOnSubtitle => 'Absorbing page shows items from all libraries';
+  String get mergeLibrariesOnSubtitle =>
+      'Absorbing page shows items from all libraries';
 
   @override
-  String get mergeLibrariesOffSubtitle => 'Absorbing page shows current library only';
+  String get mergeLibrariesOffSubtitle =>
+      'Absorbing page shows current library only';
 
   @override
   String get queueMode => 'Queue mode';
@@ -1069,13 +1104,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get queueModeInfoOff => 'Off';
 
   @override
-  String get queueModeInfoOffDesc => 'Playback stops when the current book or episode finishes.';
+  String get queueModeInfoOffDesc =>
+      'Playback stops when the current book or episode finishes.';
 
   @override
   String get queueModeInfoManual => 'Manual Queue';
 
   @override
-  String get queueModeInfoManualDesc => 'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
+  String get queueModeInfoManualDesc =>
+      'Your absorbing cards act as a playlist. When one finishes, the next non-finished card auto-plays. Add items with the \"Add to Absorbing\" button on a book or episode and reorder from the absorbing screen.';
 
   @override
   String get queueModeOff => 'Off';
@@ -1093,7 +1130,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1145,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1162,7 +1201,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get defaultSpeed => 'Default speed';
 
   @override
-  String get defaultSpeedSubtitle => 'New books start at this speed - each book remembers its own';
+  String get defaultSpeedSubtitle =>
+      'New books start at this speed - each book remembers its own';
 
   @override
   String get skipBack => 'Skip back';
@@ -1171,37 +1211,45 @@ class AppLocalizationsRu extends AppLocalizations {
   String get skipForward => 'Skip forward';
 
   @override
-  String get chapterProgressInNotification => 'Chapter progress in notification & Android Auto';
+  String get chapterProgressInNotification =>
+      'Chapter progress in notification & Android Auto';
 
   @override
-  String get chapterProgressOnSubtitle => 'On - notification & Android Auto show chapter progress';
+  String get chapterProgressOnSubtitle =>
+      'On - notification & Android Auto show chapter progress';
 
   @override
   String get chapterProgressOffSubtitle => 'Off - they show full book progress';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => 'Auto-rewind on resume';
@@ -1227,7 +1275,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rewindAlwaysLabel => 'Always';
 
   @override
-  String get rewindAlwaysDescription => 'Rewinds every time you resume, even after quick interruptions';
+  String get rewindAlwaysDescription =>
+      'Rewinds every time you resume, even after quick interruptions';
 
   @override
   String rewindAfterDescription(String seconds) {
@@ -1238,7 +1287,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterBarrier => 'Chapter barrier';
 
   @override
-  String get chapterBarrierSubtitle => 'Don\'t auto-rewind past the start of the current chapter';
+  String get chapterBarrierSubtitle =>
+      'Don\'t auto-rewind past the start of the current chapter';
 
   @override
   String get rewindInstant => 'Instant';
@@ -1307,19 +1357,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String get resetTimerOnPause => 'Reset timer on pause';
 
   @override
-  String get resetTimerOnPauseOnSubtitle => 'Timer restarts from full duration when you resume';
+  String get resetTimerOnPauseOnSubtitle =>
+      'Timer restarts from full duration when you resume';
 
   @override
-  String get resetTimerOnPauseOffSubtitle => 'Timer continues from where it left off';
+  String get resetTimerOnPauseOffSubtitle =>
+      'Timer continues from where it left off';
 
   @override
   String get fadeVolumeBeforeSleep => 'Fade volume before sleep';
 
   @override
-  String get fadeVolumeOnSubtitle => 'Gradually lowers volume during the last 30 seconds';
+  String get fadeVolumeOnSubtitle =>
+      'Gradually lowers volume during the last 30 seconds';
 
   @override
-  String get fadeVolumeOffSubtitle => 'Playback stops immediately when timer ends';
+  String get fadeVolumeOffSubtitle =>
+      'Playback stops immediately when timer ends';
 
   @override
   String get autoSleepTimer => 'Auto sleep timer';
@@ -1330,7 +1384,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get autoSleepTimerOffSubtitle => 'Automatically start a sleep timer during a time window';
+  String get autoSleepTimerOffSubtitle =>
+      'Automatically start a sleep timer during a time window';
 
   @override
   String get windowStart => 'Window start';
@@ -1387,10 +1442,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Auto-Download Books You Start';
 
   @override
-  String get autoDownloadOnWifiInfoContent => 'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
+  String get autoDownloadOnWifiInfoContent =>
+      'When you start streaming a book, the full book downloads in the background so you\'ll have it offline without starting the download yourself. These downloads follow your Download network setting above, so set it to Any connection if you want them to run on mobile data too.';
 
   @override
-  String get autoDownloadOnWifiOnSubtitle => 'Streamed books download in the background automatically';
+  String get autoDownloadOnWifiOnSubtitle =>
+      'Streamed books download in the background automatically';
 
   @override
   String get autoDownloadOnWifiOffSubtitle => 'Off';
@@ -1402,7 +1459,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownload => 'Auto-download';
 
   @override
-  String get autoDownloadSubtitle => 'Enable per series or podcast from their detail pages';
+  String get autoDownloadSubtitle =>
+      'Enable per series or podcast from their detail pages';
 
   @override
   String get keepNext => 'Keep next';
@@ -1411,7 +1469,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get keepNextInfoTitle => 'Keep Next';
 
   @override
-  String get keepNextInfoContent => 'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
+  String get keepNextInfoContent =>
+      'The number of items to keep downloaded, including the one you\'re currently listening to. For example, \"Keep next 3\" means the current book plus the next 2 in the series or podcast will stay downloaded.';
 
   @override
   String get deleteAbsorbedDownloads => 'Delete absorbed downloads';
@@ -1420,10 +1479,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => 'Delete Absorbed Downloads';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => 'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      'When enabled, downloaded books or episodes are automatically deleted from your device after you finish listening to them. This helps free up storage space as you work through your library.';
 
   @override
-  String get deleteAbsorbedOnSubtitle => 'Finished items are removed to save space';
+  String get deleteAbsorbedOnSubtitle =>
+      'Finished items are removed to save space';
 
   @override
   String get deleteAbsorbedOffSubtitle => 'Off - finished downloads kept';
@@ -1454,13 +1515,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get streamingCacheInfoTitle => 'Streaming Cache';
 
   @override
-  String get streamingCacheInfoContent => 'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
+  String get streamingCacheInfoContent =>
+      'Caches streamed audio to disk so it doesn\'t need to be re-downloaded if you seek back or re-listen to sections. The cache is automatically managed - oldest files are removed when the size limit is reached. This is separate from fully downloaded books.';
 
   @override
   String get streamingCacheOff => 'Off';
 
   @override
-  String get streamingCacheOffSubtitle => 'Off - audio is streamed without caching';
+  String get streamingCacheOffSubtitle =>
+      'Off - audio is streamed without caching';
 
   @override
   String streamingCacheOnSubtitle(int size) {
@@ -1489,7 +1552,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showGoodreadsButton => 'Show Goodreads button';
 
   @override
-  String get showGoodreadsOnSubtitle => 'Book detail sheet shows a link to Goodreads';
+  String get showGoodreadsOnSubtitle =>
+      'Book detail sheet shows a link to Goodreads';
 
   @override
   String get showGoodreadsOffSubtitle => 'Off - Goodreads button hidden';
@@ -1501,7 +1565,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get notifications => 'Notifications';
 
   @override
-  String get notificationsSubtitle => 'For download progress and playback controls';
+  String get notificationsSubtitle =>
+      'For download progress and playback controls';
 
   @override
   String get notificationsAlreadyEnabled => 'Notifications already enabled';
@@ -1510,7 +1575,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get unrestrictedBattery => 'Unrestricted battery';
 
   @override
-  String get unrestrictedBatterySubtitle => 'Prevents Android from killing background playback';
+  String get unrestrictedBatterySubtitle =>
+      'Prevents Android from killing background playback';
 
   @override
   String get batteryAlreadyUnrestricted => 'Battery already unrestricted';
@@ -1540,16 +1606,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get enableLogging => 'Enable logging';
 
   @override
-  String get enableLoggingOnSubtitle => 'On - logs saved to file (restart to apply)';
+  String get enableLoggingOnSubtitle =>
+      'On - logs saved to file (restart to apply)';
 
   @override
   String get enableLoggingOffSubtitle => 'Off - no logs captured';
 
   @override
-  String get loggingEnabledSnackbar => 'Logging enabled - restart app to start capturing';
+  String get loggingEnabledSnackbar =>
+      'Logging enabled - restart app to start capturing';
 
   @override
-  String get loggingDisabledSnackbar => 'Logging disabled - restart app to stop capturing';
+  String get loggingDisabledSnackbar =>
+      'Logging disabled - restart app to stop capturing';
 
   @override
   String get sendLogs => 'Send logs';
@@ -1578,7 +1647,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get localServerInfoTitle => 'Local Server';
 
   @override
-  String get localServerInfoContent => 'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
+  String get localServerInfoContent =>
+      'If you run your Audiobookshelf server at home, you can set a local/LAN URL here. Absorb will automatically switch to the faster local connection when it detects you\'re on your home network, and fall back to your remote URL when you\'re away.';
 
   @override
   String get localServerOnConnectedSubtitle => 'Connected via local server';
@@ -1587,7 +1657,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get localServerOnRemoteSubtitle => 'Enabled - using remote server';
 
   @override
-  String get localServerOffSubtitle => 'Auto-switch to a LAN server on your home WiFi';
+  String get localServerOffSubtitle =>
+      'Auto-switch to a LAN server on your home WiFi';
 
   @override
   String get localServerUrlLabel => 'Local server URL';
@@ -1596,7 +1667,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get localServerUrlHint => 'http://192.168.1.100:13378';
 
   @override
-  String get localServerUrlSetSnackbar => 'Local server URL set - will connect automatically when on your home network';
+  String get localServerUrlSetSnackbar =>
+      'Local server URL set - will connect automatically when on your home network';
 
   @override
   String get disableAudioFocus => 'Disable audio focus';
@@ -1605,19 +1677,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String get disableAudioFocusInfoTitle => 'Audio Focus';
 
   @override
-  String get disableAudioFocusInfoContent => 'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
+  String get disableAudioFocusInfoContent =>
+      'By default, Android gives audio \"focus\" to one app at a time - when Absorb plays, other audio (music, videos) will pause. Disabling audio focus lets Absorb play alongside other apps. Phone calls will still pause playback regardless of this setting.';
 
   @override
-  String get disableAudioFocusOnSubtitle => 'On - plays alongside other audio (still pauses for calls)';
+  String get disableAudioFocusOnSubtitle =>
+      'On - plays alongside other audio (still pauses for calls)';
 
   @override
-  String get disableAudioFocusOffSubtitle => 'Off - other audio pauses when Absorb plays';
+  String get disableAudioFocusOffSubtitle =>
+      'Off - other audio pauses when Absorb plays';
 
   @override
   String get restartRequired => 'Restart Required';
 
   @override
-  String get restartRequiredContent => 'Audio focus change requires a full restart to take effect. Close the app now?';
+  String get restartRequiredContent =>
+      'Audio focus change requires a full restart to take effect. Close the app now?';
 
   @override
   String get closeApp => 'Close App';
@@ -1629,13 +1705,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => 'Self-signed Certificates';
 
   @override
-  String get trustAllCertificatesInfoContent => 'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
+  String get trustAllCertificatesInfoContent =>
+      'Enable this if your Audiobookshelf server uses a self-signed certificate or a custom root CA. When enabled, Absorb will skip TLS certificate verification for all connections. Only enable this if you trust your network.';
 
   @override
-  String get trustAllCertificatesOnSubtitle => 'On - accepting all certificates';
+  String get trustAllCertificatesOnSubtitle =>
+      'On - accepting all certificates';
 
   @override
-  String get trustAllCertificatesOffSubtitle => 'Off - only trusted certificates accepted';
+  String get trustAllCertificatesOffSubtitle =>
+      'Off - only trusted certificates accepted';
 
   @override
   String get supportTheDev => 'Поддержать разработчика';
@@ -1657,7 +1736,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get backupAndRestore => 'Backup & Restore';
 
   @override
-  String get backupAndRestoreSubtitle => 'Save or restore all your settings to a file';
+  String get backupAndRestoreSubtitle =>
+      'Save or restore all your settings to a file';
 
   @override
   String get backUp => 'Back up';
@@ -1684,7 +1764,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get includeLoginInfoTitle => 'Include login info?';
 
   @override
-  String get includeLoginInfoContent => 'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
+  String get includeLoginInfoContent =>
+      'Would you like to include login credentials for all your saved accounts in the backup?\n\nThis makes it easy to restore on a new device, but the file will contain your auth tokens.';
 
   @override
   String get noSettingsOnly => 'No, settings only';
@@ -1707,7 +1788,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get restoreBackupTitle => 'Restore backup?';
 
   @override
-  String get restoreBackupContent => 'This will replace all your current settings with the backup values.';
+  String get restoreBackupContent =>
+      'This will replace all your current settings with the backup values.';
 
   @override
   String fromAbsorbVersion(String version) {
@@ -1742,7 +1824,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get logOutTitle => 'Log out?';
 
   @override
-  String get logOutContent => 'This will sign you out. Your downloads will stay on this device.';
+  String get logOutContent =>
+      'This will sign you out. Your downloads will stay on this device.';
 
   @override
   String get signOut => 'Выйти';
@@ -1793,13 +1876,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get downloadLocationSheetTitle => 'Download Location';
 
   @override
-  String get downloadLocationSheetSubtitle => 'Choose where audiobooks are saved';
+  String get downloadLocationSheetSubtitle =>
+      'Choose where audiobooks are saved';
 
   @override
   String get currentLocation => 'Current location';
 
   @override
-  String get existingDownloadsWarning => 'Existing downloads stay in their current location. Only new downloads use the new path.';
+  String get existingDownloadsWarning =>
+      'Existing downloads stay in their current location. Only new downloads use the new path.';
 
   @override
   String get chooseFolder => 'Choose folder';
@@ -1808,16 +1893,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chooseDownloadFolder => 'Choose download folder';
 
   @override
-  String get storagePermissionDenied => 'Storage permission permanently denied - enable it in app settings';
+  String get storagePermissionDenied =>
+      'Storage permission permanently denied - enable it in app settings';
 
   @override
   String get openSettings => 'Open Settings';
 
   @override
-  String get storagePermissionRequired => 'Storage permission is required for custom download locations';
+  String get storagePermissionRequired =>
+      'Storage permission is required for custom download locations';
 
   @override
-  String get cannotWriteToFolder => 'Cannot write to that folder - choose another location or grant file access in system settings';
+  String get cannotWriteToFolder =>
+      'Cannot write to that folder - choose another location or grant file access in system settings';
 
   @override
   String downloadLocationSetTo(String label) {
@@ -1835,8 +1923,10 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1938,7 +2028,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminRmabUrlTitle => 'ReadMeABook URL';
 
   @override
-  String get adminRmabUrlHelp => 'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
+  String get adminRmabUrlHelp =>
+      'Paste your URL with login token. Generate one in RMAB, Admin, Users.';
 
   @override
   String get adminRmabUrlHint => 'https://rmab.example.com/?token=...';
@@ -1956,7 +2047,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminRmabReload => 'Reload';
 
   @override
-  String get adminRmabLoadFailed => 'Couldn\'t load ReadMeABook. Check your URL.';
+  String get adminRmabLoadFailed =>
+      'Couldn\'t load ReadMeABook. Check your URL.';
 
   @override
   String get adminRmabConnected => 'Connected';
@@ -1976,19 +2068,23 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => 'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
+  String get adminRmabUrlHelpUser =>
+      'Get a login URL from your server admin. They generate one in RMAB > Admin > Users.';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook is a self-hosted service for requesting and downloading audiobooks. It must be installed and set up by your server admin.';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2108,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2135,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2177,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2205,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2215,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2243,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2468,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => 'About';
@@ -2400,31 +2504,36 @@ class AppLocalizationsRu extends AppLocalizations {
   String get markAsFullyAbsorbedQuestion => 'Mark as Fully Absorbed?';
 
   @override
-  String get markAsFullyAbsorbedContent => 'This will set your progress to 100% and stop playback if this book is playing.';
+  String get markAsFullyAbsorbedContent =>
+      'This will set your progress to 100% and stop playback if this book is playing.';
 
   @override
   String get markedAsFinishedNiceWork => 'Marked as finished - nice work!';
 
   @override
-  String get failedToUpdateCheckConnection => 'Failed to update - check your connection';
+  String get failedToUpdateCheckConnection =>
+      'Failed to update - check your connection';
 
   @override
   String get markAsNotFinishedQuestion => 'Mark as Not Finished?';
 
   @override
-  String get markAsNotFinishedContent => 'This will clear the finished status but keep your current position.';
+  String get markAsNotFinishedContent =>
+      'This will clear the finished status but keep your current position.';
 
   @override
   String get unmark => 'Unmark';
 
   @override
-  String get markedAsNotFinishedBackAtIt => 'Marked as not finished - back at it!';
+  String get markedAsNotFinishedBackAtIt =>
+      'Marked as not finished - back at it!';
 
   @override
   String get resetProgressQuestion => 'Reset Progress?';
 
   @override
-  String get resetProgressContent => 'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
+  String get resetProgressContent =>
+      'This will erase all progress for this book and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get progressResetFreshStart => 'Progress reset - fresh start!';
@@ -2433,7 +2542,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get clearLocalMetadataQuestion => 'Clear Local Metadata?';
 
   @override
-  String get clearLocalMetadataContent => 'This will remove the locally stored metadata and revert to whatever the server has.';
+  String get clearLocalMetadataContent =>
+      'This will remove the locally stored metadata and revert to whatever the server has.';
 
   @override
   String get localMetadataCleared => 'Local metadata cleared';
@@ -2462,7 +2572,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noBookmarksYet => 'No bookmarks yet';
 
   @override
-  String get longPressBookmarkHint => 'Long-press the bookmark button to quick save';
+  String get longPressBookmarkHint =>
+      'Long-press the bookmark button to quick save';
 
   @override
   String get addBookmark => 'Add Bookmark';
@@ -2545,7 +2656,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownloadThisSeries => 'Auto-Download This Series?';
 
   @override
-  String get autoDownloadSeriesContent => 'Automatically download the next books as you listen.';
+  String get autoDownloadSeriesContent =>
+      'Automatically download the next books as you listen.';
 
   @override
   String get standalone => 'Standalone';
@@ -2583,7 +2695,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoDownloadThisPodcast => 'Auto-Download This Podcast?';
 
   @override
-  String get autoDownloadPodcastContent => 'Automatically download the next episodes as you listen.';
+  String get autoDownloadPodcastContent =>
+      'Automatically download the next episodes as you listen.';
 
   @override
   String get download => 'Download';
@@ -2610,7 +2723,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get authorOptionalLabel => 'Author (optional)';
 
   @override
-  String get noResultsFound => 'No results found.\nTry adjusting your search or provider.';
+  String get noResultsFound =>
+      'No results found.\nTry adjusting your search or provider.';
 
   @override
   String get searchForMetadataAbove => 'Search for metadata above';
@@ -2760,13 +2874,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteCollection => 'Delete Collection';
 
   @override
-  String get deleteCollectionContent => 'Are you sure you want to delete this collection?';
+  String get deleteCollectionContent =>
+      'Are you sure you want to delete this collection?';
 
   @override
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => 'Playlist not found';
@@ -2775,7 +2891,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deletePlaylist => 'Delete Playlist';
 
   @override
-  String get deletePlaylistContent => 'Are you sure you want to delete this playlist?';
+  String get deletePlaylistContent =>
+      'Are you sure you want to delete this playlist?';
 
   @override
   String get newPlaylist => 'New Playlist';
@@ -2828,10 +2945,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get welcomeAbsorbingTitle => 'Absorbing';
 
   @override
-  String get welcomeAbsorbingIntro => 'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
+  String get welcomeAbsorbingIntro =>
+      'We use \"absorb\" in place of \"play\" and \"listen\". Prefer the classic wording? Switch it in Settings.';
 
   @override
-  String get welcomeAbsorbingTabBullet => 'Absorbing tab - what you\'re currently listening to';
+  String get welcomeAbsorbingTabBullet =>
+      'Absorbing tab - what you\'re currently listening to';
 
   @override
   String get welcomeAbsorbButtonBullet => 'Absorb button - start playback';
@@ -2843,13 +2962,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get welcomeGettingAroundTitle => 'Getting around';
 
   @override
-  String get welcomeGettingAroundBody => 'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
+  String get welcomeGettingAroundBody =>
+      'Tap any cover to open its details. Continue Listening cards are different - tap to play right away, press and hold to open details.';
 
   @override
   String get welcomeMakeItYoursTitle => 'Make it yours';
 
   @override
-  String get welcomeMakeItYoursBody => 'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
+  String get welcomeMakeItYoursBody =>
+      'Mess around in Settings to tune Absorb to your taste. The Tips & Hidden Features section in there is worth a look.';
 
   @override
   String get getStarted => 'Get Started';
@@ -2939,7 +3060,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +3073,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3086,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3112,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3132,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3187,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3207,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3225,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3238,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3287,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3442,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3522,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3531,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3832,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4107,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4117,24 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4244,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4254,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4324,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4390,20 @@ class AppLocalizationsRu extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4555,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4624,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4738,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4841,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4991,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -4945,7 +5103,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get sleepTimerSheetSpecificAlreadyPassed => 'This point has already passed';
+  String get sleepTimerSheetSpecificAlreadyPassed =>
+      'This point has already passed';
 
   @override
   String get sleepTimerSheetSpecificStartButton => 'Start timer';
@@ -5031,7 +5190,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5200,141 @@ class AppLocalizationsRu extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5487,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5553,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5600,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5610,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5466,7 +5651,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showTipsAgain => 'Show tips again';
 
   @override
-  String get showTipsAgainSubtitle => 'Bring back feature tips you\'ve dismissed';
+  String get showTipsAgainSubtitle =>
+      'Bring back feature tips you\'ve dismissed';
 
   @override
   String get tipsRestored => 'Tips restored';
@@ -5475,7 +5661,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get resetSpeedPresets => 'Reset speed presets';
 
   @override
-  String get resetSpeedPresetsSubtitle => 'Restore the default playback speed chips';
+  String get resetSpeedPresetsSubtitle =>
+      'Restore the default playback speed chips';
 
   @override
   String get speedPresetsReset => 'Speed presets reset';
@@ -5496,7 +5683,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5710,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5738,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5814,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5857,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5902,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5928,12 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5945,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5967,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +6005,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +6014,8 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6106,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6146,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6240,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6382,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6505,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2160,6 +2160,44 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabMyRequestsRefresh => 'Refresh';
 
   @override
+  String get rmabApprovalsTab => 'Approvals';
+
+  @override
+  String get rmabApprovalsEmpty => 'No requests awaiting approval';
+
+  @override
+  String get rmabApprovalsError => 'Couldn\'t load approvals';
+
+  @override
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalApprove => 'Approve';
+
+  @override
+  String get rmabApprovalDeny => 'Deny';
+
+  @override
+  String get rmabApprovalApproved => 'Request approved';
+
+  @override
+  String get rmabApprovalDenied => 'Request denied';
+
+  @override
+  String rmabApprovalRequestedBy(String name) {
+    return 'Requested by $name';
+  }
+
+  @override
+  String get rmabApprovalDenyConfirmTitle => 'Deny this request?';
+
+  @override
+  String rmabApprovalDenyConfirmBody(String title) {
+    return '“$title” won\'t be downloaded and the requester will be notified.';
+  }
+
+  @override
   String get rmabRequestDetailTitle => 'Request details';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -153,8 +153,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get loginCustomHttpHeaders => '自定义 HTTP 请求头';
 
   @override
-  String get loginCustomHeadersDescription =>
-      '用于需要额外请求头的 Cloudflare 隧道或反向代理。请在输入服务器 URL 之前添加请求头。';
+  String get loginCustomHeadersDescription => '用于需要额外请求头的 Cloudflare 隧道或反向代理。请在输入服务器 URL 之前添加请求头。';
 
   @override
   String get loginHeaderName => '请求头名称';
@@ -175,8 +174,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get loginApiKey => 'API 密钥';
 
   @override
-  String get loginApiKeyDescription =>
-      '使用管理员生成的 API 密钥代替用户名/密码。当账号的令牌刷新失败时很有用。';
+  String get loginApiKeyDescription => '使用管理员生成的 API 密钥代替用户名/密码。当账号的令牌刷新失败时很有用。';
 
   @override
   String get loginWaitingForSso => '正在等待单点登录(SSO)...';
@@ -224,12 +222,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders =>
-      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote =>
-      'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -238,8 +234,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError =>
-      'Could not create an API key for this user';
+  String get adminSetupFileKeyError => 'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -936,8 +931,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription =>
-      'Use a fixed app color you choose below';
+  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -946,15 +940,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle =>
-      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle =>
-      'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1041,8 +1033,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get whenAbsorbedInfoTitle => '当收听完成时';
 
   @override
-  String get whenAbsorbedInfoContent =>
-      '控制当您完成一本书或一集后收听卡片的行为。\n\n已完成的卡片会自动从从您的“正在收听”屏幕中移除。';
+  String get whenAbsorbedInfoContent => '控制当您完成一本书或一集后收听卡片的行为。\n\n已完成的卡片会自动从从您的“正在收听”屏幕中移除。';
 
   @override
   String get whenAbsorbedSubtitle => '听完一本书或或一集后收听卡片的处理方式';
@@ -1060,8 +1051,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mergeLibrariesInfoTitle => '合并媒体库';
 
   @override
-  String get mergeLibrariesInfoContent =>
-      '启用后，“正在收听”界面会将您所有媒体库中正在进行的书籍和播客集中显示在一个视图中。禁用时，仅显示您当前所选媒体库中的项目。';
+  String get mergeLibrariesInfoContent => '启用后，“正在收听”界面会将您所有媒体库中正在进行的书籍和播客集中显示在一个视图中。禁用时，仅显示您当前所选媒体库中的项目。';
 
   @override
   String get mergeLibrariesOnSubtitle => '正在收听页面显示来自所有媒体库的项目';
@@ -1085,8 +1075,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get queueModeInfoManual => '手动队列';
 
   @override
-  String get queueModeInfoManualDesc =>
-      '你的收听卡片将作为播放列表使用。当一个播放完成时，会自动播放下一个未完成的卡片。通过书籍或单集详情页的\"添加至正在收听\"按钮添加项目，并在收听界面重新排序。';
+  String get queueModeInfoManualDesc => '你的收听卡片将作为播放列表使用。当一个播放完成时，会自动播放下一个未完成的卡片。通过书籍或单集详情页的\"添加至正在收听\"按钮添加项目，并在收听界面重新排序。';
 
   @override
   String get queueModeOff => '关闭';
@@ -1104,8 +1093,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc =>
-      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1119,8 +1107,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint =>
-      'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1193,34 +1180,28 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterProgressOffSubtitle => '关闭 - 锁屏显示全书进度';
 
   @override
-  String get chapterProgressInNotificationIos =>
-      'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos =>
-      'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle =>
-      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle =>
-      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle =>
-      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle =>
-      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => '恢复播放时自动倒退';
@@ -1406,8 +1387,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Wi-Fi 下自动下载';
 
   @override
-  String get autoDownloadOnWifiInfoContent =>
-      '当你在 Wi-Fi 下开始流式播放一本书时，它将自动在后台下载整本书。这样你无需手动开始下载即可离线收听。';
+  String get autoDownloadOnWifiInfoContent => '当你在 Wi-Fi 下开始流式播放一本书时，它将自动在后台下载整本书。这样你无需手动开始下载即可离线收听。';
 
   @override
   String get autoDownloadOnWifiOnSubtitle => '在 Wi-Fi 下开始流式播放时，书籍将在后台下载';
@@ -1431,8 +1411,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get keepNextInfoTitle => '保留接下来';
 
   @override
-  String get keepNextInfoContent =>
-      '要保留下载的项目数量，包括你当前正在收听的项目。例如，\"保留接下来3个\"意味着当前书籍加上系列或播客中的下2本将保持下载状态。';
+  String get keepNextInfoContent => '要保留下载的项目数量，包括你当前正在收听的项目。例如，\"保留接下来3个\"意味着当前书籍加上系列或播客中的下2本将保持下载状态。';
 
   @override
   String get deleteAbsorbedDownloads => '删除已完成的下载';
@@ -1441,8 +1420,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => '删除已完成的下载';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent =>
-      '启用后，听完的书籍或剧集将自动从设备中删除。这有助于在你浏览媒体库时释放存储空间。';
+  String get deleteAbsorbedDownloadsInfoContent => '启用后，听完的书籍或剧集将自动从设备中删除。这有助于在你浏览媒体库时释放存储空间。';
 
   @override
   String get deleteAbsorbedOnSubtitle => '已完成项目将被移除以节省空间';
@@ -1476,8 +1454,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get streamingCacheInfoTitle => '流式缓存';
 
   @override
-  String get streamingCacheInfoContent =>
-      '将流式播放的音频缓存到磁盘，以便在快退或重复收听时无需重新下载。缓存会自动管理 - 达到大小限制时，最旧的文件会被移除。这与完全下载的书籍是分开的';
+  String get streamingCacheInfoContent => '将流式播放的音频缓存到磁盘，以便在快退或重复收听时无需重新下载。缓存会自动管理 - 达到大小限制时，最旧的文件会被移除。这与完全下载的书籍是分开的';
 
   @override
   String get streamingCacheOff => '关闭';
@@ -1601,8 +1578,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get localServerInfoTitle => '本地服务器';
 
   @override
-  String get localServerInfoContent =>
-      '如果你在家运行 Audiobookshelf 服务器，可以在此设置本地/局域网 URL。Absorb 在检测到您处于家庭网络时会自动切换到更快的本地连接，而在外出时则回退到远程 URL。';
+  String get localServerInfoContent => '如果你在家运行 Audiobookshelf 服务器，可以在此设置本地/局域网 URL。Absorb 在检测到您处于家庭网络时会自动切换到更快的本地连接，而在外出时则回退到远程 URL。';
 
   @override
   String get localServerOnConnectedSubtitle => '已通过本地服务器连接';
@@ -1629,8 +1605,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get disableAudioFocusInfoTitle => '音频焦点';
 
   @override
-  String get disableAudioFocusInfoContent =>
-      '默认情况下，Android 一次只给一个应用音频“焦点” - 当 Absorb 播放时，其他音频（音乐、视频）会暂停。禁用音频焦点可让 Absorb 与其他应用同时播放。无论此设置如何，来电时始终会暂停播放。';
+  String get disableAudioFocusInfoContent => '默认情况下，Android 一次只给一个应用音频“焦点” - 当 Absorb 播放时，其他音频（音乐、视频）会暂停。禁用音频焦点可让 Absorb 与其他应用同时播放。无论此设置如何，来电时始终会暂停播放。';
 
   @override
   String get disableAudioFocusOnSubtitle => '开启 - 与其他音频同时播放（来电时仍会暂停）';
@@ -1654,8 +1629,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => '自签名证书';
 
   @override
-  String get trustAllCertificatesInfoContent =>
-      '如果你的 Audiobookshelf 服务器使用自签名证书或自定义根 CA，请启用此选项。启用后，Absorb 将跳过所有连接的 TLS 证书验证。仅在您信任当前网络环境时启用。';
+  String get trustAllCertificatesInfoContent => '如果你的 Audiobookshelf 服务器使用自签名证书或自定义根 CA，请启用此选项。启用后，Absorb 将跳过所有连接的 TLS 证书验证。仅在您信任当前网络环境时启用。';
 
   @override
   String get trustAllCertificatesOnSubtitle => '开启 - 接受所有证书';
@@ -1710,8 +1684,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get includeLoginInfoTitle => '包含登录信息？';
 
   @override
-  String get includeLoginInfoContent =>
-      '你是否希望在备份中包含所有已保存账号的登录凭据？\n\n这会让在新设备上恢复变得容易，但文件中将包含您的身份验证令牌。';
+  String get includeLoginInfoContent => '你是否希望在备份中包含所有已保存账号的登录凭据？\n\n这会让在新设备上恢复变得容易，但文件中将包含您的身份验证令牌。';
 
   @override
   String get noSettingsOnly => '否，仅设置';
@@ -1862,10 +1835,8 @@ class AppLocalizationsZh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one:
-          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -2005,23 +1976,19 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser =>
-      '请向您的服务器管理员获取登录 URL，管理员可在 RMAB 的管理 -> 用户中生成。';
+  String get adminRmabUrlHelpUser => '请向您的服务器管理员获取登录 URL，管理员可在 RMAB 的管理 -> 用户中生成。';
 
   @override
-  String get adminRmabSettingsInfo =>
-      'ReadMeABook 是一个用于请求和下载有声书的自托管服务，需要由您的服务器管理员安装和设置。';
+  String get adminRmabSettingsInfo => 'ReadMeABook 是一个用于请求和下载有声书的自托管服务，需要由您的服务器管理员安装和设置。';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser =>
-      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2045,8 +2012,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp =>
-      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2072,8 +2038,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden =>
-      'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2114,8 +2079,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer =>
-      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2142,8 +2106,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound =>
-      'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2152,8 +2115,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected =>
-      'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2180,8 +2142,29 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden =>
-      'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+
+  @override
+  String get rmabApprovalNotifsTitle => 'Approval notifications';
+
+  @override
+  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+
+  @override
+  String get rmabApprovalNotifsDenied => 'Notification permission was denied';
+
+  @override
+  String get rmabApprovalNotifTitle => 'Approvals waiting';
+
+  @override
+  String rmabApprovalNotifBodyOne(String title) {
+    return '“$title” needs your approval';
+  }
+
+  @override
+  String rmabApprovalNotifBodyMany(int count) {
+    return '$count requests need your approval';
+  }
 
   @override
   String get rmabApprovalApprove => 'Approve';
@@ -2382,8 +2365,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote =>
-      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => '关于';
@@ -2784,8 +2766,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired =>
-      'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => '未找到播放列表';
@@ -2862,15 +2843,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get welcomeGettingAroundTitle => '界面操作';
 
   @override
-  String get welcomeGettingAroundBody =>
-      '点击任意封面打开详情。继续收听卡片不一样 - 点击立即播放，长按打开详情。';
+  String get welcomeGettingAroundBody => '点击任意封面打开详情。继续收听卡片不一样 - 点击立即播放，长按打开详情。';
 
   @override
   String get welcomeMakeItYoursTitle => '个性化设置';
 
   @override
-  String get welcomeMakeItYoursBody =>
-      '在设置中自定义 Absorb 以符合你的喜好。其中的「技巧与隐藏功能」区块值得一看。';
+  String get welcomeMakeItYoursBody => '在设置中自定义 Absorb 以符合你的喜好。其中的「技巧与隐藏功能」区块值得一看。';
 
   @override
   String get getStarted => '开始使用';
@@ -2960,8 +2939,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle =>
-      'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2973,8 +2951,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle =>
-      'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2986,15 +2963,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc =>
-      'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent =>
-      'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -3012,16 +2987,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent =>
-      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle =>
-      'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle =>
-      'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3032,8 +3004,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent =>
-      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3087,8 +3058,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle =>
-      'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3107,8 +3077,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(
-      String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3125,8 +3094,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle =>
-      'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3138,15 +3106,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent =>
-      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle =>
-      'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3187,8 +3153,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied =>
-      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3342,8 +3307,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed =>
-      'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3422,8 +3386,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced =>
-      'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3431,8 +3394,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage =>
-      'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3732,12 +3694,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent =>
-      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle =>
-      'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -4007,8 +3967,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew =>
-      'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -4017,24 +3976,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle =>
-      'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes =>
-      'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle =>
-      'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle =>
-      'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate =>
-      'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4144,8 +4098,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes =>
-      'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4154,8 +4107,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent =>
-      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4224,12 +4176,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent =>
-      'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent =>
-      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4290,20 +4240,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent =>
-      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible =>
-      'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other:
-          'This will clear the finished status for all $count books in this series.',
+      other: 'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4455,8 +4402,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody =>
-      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4524,8 +4470,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(
-      String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4638,8 +4583,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound =>
-      'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4741,8 +4685,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(
-      int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4891,8 +4834,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle =>
-      'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5089,8 +5031,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle =>
-      'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5099,141 +5040,121 @@ class AppLocalizationsZh extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc =>
-      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc =>
-      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc =>
-      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc =>
-      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc =>
-      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc =>
-      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc =>
-      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc =>
-      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc =>
-      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc =>
-      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc =>
-      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc =>
-      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc =>
-      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc =>
-      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc =>
-      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc =>
-      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc =>
-      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc =>
-      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc =>
-      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc =>
-      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5386,8 +5307,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail =>
-      'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5452,15 +5372,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc =>
-      'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc =>
-      'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5499,8 +5417,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc =>
-      'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5509,8 +5426,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(
-      String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5580,8 +5496,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm =>
-      'This deletes the image on the server.';
+  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5607,8 +5522,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint =>
-      'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5635,8 +5549,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious =>
-      'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5711,8 +5624,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage =>
-      'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5754,8 +5666,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint =>
-      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5799,8 +5710,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle =>
-      'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5825,12 +5735,10 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger =>
-      'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter =>
-      'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5842,8 +5750,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint =>
-      'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5864,23 +5771,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro =>
-      'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder =>
-      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack =>
-      'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway =>
-      'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5902,8 +5805,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro =>
-      'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5911,8 +5813,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro =>
-      '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -6003,8 +5904,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning =>
-      'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -6043,8 +5943,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub =>
-      'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6137,8 +6036,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle =>
-      'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6279,8 +6177,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody =>
-      'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6402,6 +6299,5 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody =>
-      'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1994,6 +1994,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminRmabAskAdmin => '请向您的服务器管理员获取登录 URL';
 
   @override
+  String adminRmabApprovalsPending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count requests awaiting approval',
+      one: '1 request awaiting approval',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get adminRmabUrlHelpUser =>
       '请向您的服务器管理员获取登录 URL，管理员可在 RMAB 的管理 -> 用户中生成。';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -153,7 +153,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get loginCustomHttpHeaders => '自定义 HTTP 请求头';
 
   @override
-  String get loginCustomHeadersDescription => '用于需要额外请求头的 Cloudflare 隧道或反向代理。请在输入服务器 URL 之前添加请求头。';
+  String get loginCustomHeadersDescription =>
+      '用于需要额外请求头的 Cloudflare 隧道或反向代理。请在输入服务器 URL 之前添加请求头。';
 
   @override
   String get loginHeaderName => '请求头名称';
@@ -174,7 +175,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get loginApiKey => 'API 密钥';
 
   @override
-  String get loginApiKeyDescription => '使用管理员生成的 API 密钥代替用户名/密码。当账号的令牌刷新失败时很有用。';
+  String get loginApiKeyDescription =>
+      '使用管理员生成的 API 密钥代替用户名/密码。当账号的令牌刷新失败时很有用。';
 
   @override
   String get loginWaitingForSso => '正在等待单点登录(SSO)...';
@@ -222,10 +224,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminSetupFileServerUrl => 'Server URL the new user will use';
 
   @override
-  String get adminSetupFileNoteWithHeaders => 'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
+  String get adminSetupFileNoteWithHeaders =>
+      'An API key will be created for this user and your custom headers are included so they can reach the server. Treat the file like a password.';
 
   @override
-  String get adminSetupFileNote => 'An API key will be created for this user. Treat the file like a password.';
+  String get adminSetupFileNote =>
+      'An API key will be created for this user. Treat the file like a password.';
 
   @override
   String get adminSetupFileCreate => 'Create';
@@ -234,7 +238,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminSetupFileSaveTitle => 'Save setup file';
 
   @override
-  String get adminSetupFileKeyError => 'Could not create an API key for this user';
+  String get adminSetupFileKeyError =>
+      'Could not create an API key for this user';
 
   @override
   String adminSetupFileSaved(String username) {
@@ -931,7 +936,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get colorSourceManual => 'Manual';
 
   @override
-  String get colorSourceManualDescription => 'Use a fixed app color you choose below';
+  String get colorSourceManualDescription =>
+      'Use a fixed app color you choose below';
 
   @override
   String get colorSourceCustom => 'Custom';
@@ -940,13 +946,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get useColorEverywhereLabel => 'Use this color everywhere';
 
   @override
-  String get useColorEverywhereSubtitle => 'Also color book detail pages and the player card with your set color instead of each book\'s cover';
+  String get useColorEverywhereSubtitle =>
+      'Also color book detail pages and the player card with your set color instead of each book\'s cover';
 
   @override
   String get flatBackgroundLabel => 'Flat background';
 
   @override
-  String get flatBackgroundSubtitle => 'Remove the background gradient. Pure black in dark mode for OLED screens.';
+  String get flatBackgroundSubtitle =>
+      'Remove the background gradient. Pure black in dark mode for OLED screens.';
 
   @override
   String get backgroundIntensityLabel => 'Background intensity';
@@ -1033,7 +1041,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get whenAbsorbedInfoTitle => '当收听完成时';
 
   @override
-  String get whenAbsorbedInfoContent => '控制当您完成一本书或一集后收听卡片的行为。\n\n已完成的卡片会自动从从您的“正在收听”屏幕中移除。';
+  String get whenAbsorbedInfoContent =>
+      '控制当您完成一本书或一集后收听卡片的行为。\n\n已完成的卡片会自动从从您的“正在收听”屏幕中移除。';
 
   @override
   String get whenAbsorbedSubtitle => '听完一本书或或一集后收听卡片的处理方式';
@@ -1051,7 +1060,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mergeLibrariesInfoTitle => '合并媒体库';
 
   @override
-  String get mergeLibrariesInfoContent => '启用后，“正在收听”界面会将您所有媒体库中正在进行的书籍和播客集中显示在一个视图中。禁用时，仅显示您当前所选媒体库中的项目。';
+  String get mergeLibrariesInfoContent =>
+      '启用后，“正在收听”界面会将您所有媒体库中正在进行的书籍和播客集中显示在一个视图中。禁用时，仅显示您当前所选媒体库中的项目。';
 
   @override
   String get mergeLibrariesOnSubtitle => '正在收听页面显示来自所有媒体库的项目';
@@ -1075,7 +1085,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get queueModeInfoManual => '手动队列';
 
   @override
-  String get queueModeInfoManualDesc => '你的收听卡片将作为播放列表使用。当一个播放完成时，会自动播放下一个未完成的卡片。通过书籍或单集详情页的\"添加至正在收听\"按钮添加项目，并在收听界面重新排序。';
+  String get queueModeInfoManualDesc =>
+      '你的收听卡片将作为播放列表使用。当一个播放完成时，会自动播放下一个未完成的卡片。通过书籍或单集详情页的\"添加至正在收听\"按钮添加项目，并在收听界面重新排序。';
 
   @override
   String get queueModeOff => '关闭';
@@ -1093,7 +1104,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get queueModeInfoPlaylist => 'Playlist Queue';
 
   @override
-  String get queueModeInfoPlaylistDesc => 'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
+  String get queueModeInfoPlaylistDesc =>
+      'Plays items in order from a chosen playlist, skipping anything already finished. Stops at the end of the list.';
 
   @override
   String get queuePlaylistPickerTitle => 'Choose a playlist';
@@ -1107,7 +1119,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get queueModePlaylistHint => 'Start a playlist queue by opening a playlist on the home page.';
+  String get queueModePlaylistHint =>
+      'Start a playlist queue by opening a playlist on the home page.';
 
   @override
   String get exit => 'Exit';
@@ -1180,28 +1193,34 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterProgressOffSubtitle => '关闭 - 锁屏显示全书进度';
 
   @override
-  String get chapterProgressInNotificationIos => 'Chapter progress on lock screen & CarPlay';
+  String get chapterProgressInNotificationIos =>
+      'Chapter progress on lock screen & CarPlay';
 
   @override
-  String get chapterProgressOnSubtitleIos => 'On - lock screen & CarPlay show chapter progress';
+  String get chapterProgressOnSubtitleIos =>
+      'On - lock screen & CarPlay show chapter progress';
 
   @override
   String get speedBookmarkInControls => 'Speed & bookmark in media controls';
 
   @override
-  String get speedBookmarkOnSubtitle => 'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
+  String get speedBookmarkOnSubtitle =>
+      'On - notification shows speed & bookmark; chapter skip stays in Android Auto';
 
   @override
-  String get speedBookmarkOffSubtitle => 'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
+  String get speedBookmarkOffSubtitle =>
+      'Off - notification shows chapter skip; speed & bookmark stay in Android Auto';
 
   @override
   String get lockSeekBar => 'Lock the seek bar';
 
   @override
-  String get lockSeekBarOnSubtitle => 'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
+  String get lockSeekBarOnSubtitle =>
+      'On - the scrubber in the notification, lockscreen and car shows progress but can\'t be dragged';
 
   @override
-  String get lockSeekBarOffSubtitle => 'Off - drag the scrubber in the notification, lockscreen and car to jump around';
+  String get lockSeekBarOffSubtitle =>
+      'Off - drag the scrubber in the notification, lockscreen and car to jump around';
 
   @override
   String get autoRewindOnResume => '恢复播放时自动倒退';
@@ -1387,7 +1406,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get autoDownloadOnWifiInfoTitle => 'Wi-Fi 下自动下载';
 
   @override
-  String get autoDownloadOnWifiInfoContent => '当你在 Wi-Fi 下开始流式播放一本书时，它将自动在后台下载整本书。这样你无需手动开始下载即可离线收听。';
+  String get autoDownloadOnWifiInfoContent =>
+      '当你在 Wi-Fi 下开始流式播放一本书时，它将自动在后台下载整本书。这样你无需手动开始下载即可离线收听。';
 
   @override
   String get autoDownloadOnWifiOnSubtitle => '在 Wi-Fi 下开始流式播放时，书籍将在后台下载';
@@ -1411,7 +1431,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get keepNextInfoTitle => '保留接下来';
 
   @override
-  String get keepNextInfoContent => '要保留下载的项目数量，包括你当前正在收听的项目。例如，\"保留接下来3个\"意味着当前书籍加上系列或播客中的下2本将保持下载状态。';
+  String get keepNextInfoContent =>
+      '要保留下载的项目数量，包括你当前正在收听的项目。例如，\"保留接下来3个\"意味着当前书籍加上系列或播客中的下2本将保持下载状态。';
 
   @override
   String get deleteAbsorbedDownloads => '删除已完成的下载';
@@ -1420,7 +1441,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get deleteAbsorbedDownloadsInfoTitle => '删除已完成的下载';
 
   @override
-  String get deleteAbsorbedDownloadsInfoContent => '启用后，听完的书籍或剧集将自动从设备中删除。这有助于在你浏览媒体库时释放存储空间。';
+  String get deleteAbsorbedDownloadsInfoContent =>
+      '启用后，听完的书籍或剧集将自动从设备中删除。这有助于在你浏览媒体库时释放存储空间。';
 
   @override
   String get deleteAbsorbedOnSubtitle => '已完成项目将被移除以节省空间';
@@ -1454,7 +1476,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get streamingCacheInfoTitle => '流式缓存';
 
   @override
-  String get streamingCacheInfoContent => '将流式播放的音频缓存到磁盘，以便在快退或重复收听时无需重新下载。缓存会自动管理 - 达到大小限制时，最旧的文件会被移除。这与完全下载的书籍是分开的';
+  String get streamingCacheInfoContent =>
+      '将流式播放的音频缓存到磁盘，以便在快退或重复收听时无需重新下载。缓存会自动管理 - 达到大小限制时，最旧的文件会被移除。这与完全下载的书籍是分开的';
 
   @override
   String get streamingCacheOff => '关闭';
@@ -1578,7 +1601,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get localServerInfoTitle => '本地服务器';
 
   @override
-  String get localServerInfoContent => '如果你在家运行 Audiobookshelf 服务器，可以在此设置本地/局域网 URL。Absorb 在检测到您处于家庭网络时会自动切换到更快的本地连接，而在外出时则回退到远程 URL。';
+  String get localServerInfoContent =>
+      '如果你在家运行 Audiobookshelf 服务器，可以在此设置本地/局域网 URL。Absorb 在检测到您处于家庭网络时会自动切换到更快的本地连接，而在外出时则回退到远程 URL。';
 
   @override
   String get localServerOnConnectedSubtitle => '已通过本地服务器连接';
@@ -1605,7 +1629,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get disableAudioFocusInfoTitle => '音频焦点';
 
   @override
-  String get disableAudioFocusInfoContent => '默认情况下，Android 一次只给一个应用音频“焦点” - 当 Absorb 播放时，其他音频（音乐、视频）会暂停。禁用音频焦点可让 Absorb 与其他应用同时播放。无论此设置如何，来电时始终会暂停播放。';
+  String get disableAudioFocusInfoContent =>
+      '默认情况下，Android 一次只给一个应用音频“焦点” - 当 Absorb 播放时，其他音频（音乐、视频）会暂停。禁用音频焦点可让 Absorb 与其他应用同时播放。无论此设置如何，来电时始终会暂停播放。';
 
   @override
   String get disableAudioFocusOnSubtitle => '开启 - 与其他音频同时播放（来电时仍会暂停）';
@@ -1629,7 +1654,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get trustAllCertificatesInfoTitle => '自签名证书';
 
   @override
-  String get trustAllCertificatesInfoContent => '如果你的 Audiobookshelf 服务器使用自签名证书或自定义根 CA，请启用此选项。启用后，Absorb 将跳过所有连接的 TLS 证书验证。仅在您信任当前网络环境时启用。';
+  String get trustAllCertificatesInfoContent =>
+      '如果你的 Audiobookshelf 服务器使用自签名证书或自定义根 CA，请启用此选项。启用后，Absorb 将跳过所有连接的 TLS 证书验证。仅在您信任当前网络环境时启用。';
 
   @override
   String get trustAllCertificatesOnSubtitle => '开启 - 接受所有证书';
@@ -1684,7 +1710,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get includeLoginInfoTitle => '包含登录信息？';
 
   @override
-  String get includeLoginInfoContent => '你是否希望在备份中包含所有已保存账号的登录凭据？\n\n这会让在新设备上恢复变得容易，但文件中将包含您的身份验证令牌。';
+  String get includeLoginInfoContent =>
+      '你是否希望在备份中包含所有已保存账号的登录凭据？\n\n这会让在新设备上恢复变得容易，但文件中将包含您的身份验证令牌。';
 
   @override
   String get noSettingsOnly => '否，仅设置';
@@ -1835,8 +1862,10 @@ class AppLocalizationsZh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
-      one: '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
+      other:
+          '$count downloads are in an old custom folder that can no longer be opened. Re-download them or dismiss this notice.',
+      one:
+          '1 download is in an old custom folder that can no longer be opened. Re-download it or dismiss this notice.',
     );
     return '$_temp0';
   }
@@ -1976,19 +2005,23 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get adminRmabUrlHelpUser => '请向您的服务器管理员获取登录 URL，管理员可在 RMAB 的管理 -> 用户中生成。';
+  String get adminRmabUrlHelpUser =>
+      '请向您的服务器管理员获取登录 URL，管理员可在 RMAB 的管理 -> 用户中生成。';
 
   @override
-  String get adminRmabSettingsInfo => 'ReadMeABook 是一个用于请求和下载有声书的自托管服务，需要由您的服务器管理员安装和设置。';
+  String get adminRmabSettingsInfo =>
+      'ReadMeABook 是一个用于请求和下载有声书的自托管服务，需要由您的服务器管理员安装和设置。';
 
   @override
   String get rmabConfigTitle => 'Connect ReadMeABook';
 
   @override
-  String get rmabConfigExplainerAdmin => 'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerAdmin =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Generate an API token in RMAB under Admin Dashboard > Settings > API, then paste the server URL and token below. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
-  String get rmabConfigExplainerUser => 'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
+  String get rmabConfigExplainerUser =>
+      'ReadMeABook is a self-hosted service for requesting audiobooks. Ask your server admin for the RMAB URL and an API token. Absorb doesn\'t host or download any content, it just sends requests to your server.';
 
   @override
   String get rmabConfigLearnMore => 'Learn more about ReadMeABook';
@@ -2012,7 +2045,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabConfigLegacyUrlHint => 'https://rmab.example.com/?token=...';
 
   @override
-  String get rmabConfigLegacyUrlHelp => 'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
+  String get rmabConfigLegacyUrlHelp =>
+      'Paste your auto-login URL so \'Open in browser view\' lands you signed in. Leave blank to use a regular login.';
 
   @override
   String get rmabConfigConnect => 'Connect';
@@ -2038,7 +2072,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabConfigErrorUnauthorized => 'Token rejected by server';
 
   @override
-  String get rmabConfigErrorForbidden => 'This token isn\'t allowed for that action';
+  String get rmabConfigErrorForbidden =>
+      'This token isn\'t allowed for that action';
 
   @override
   String get rmabConfigErrorNetwork => 'Couldn\'t reach RMAB. Check the URL.';
@@ -2079,7 +2114,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get rmabBookDetailExplainer => 'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
+  String get rmabBookDetailExplainer =>
+      'This request will be sent through your ReadMeABook server. The admin will review and process it. You can track it under My Requests on the ReadMeABook tile.';
 
   @override
   String get rmabBookAlreadyAvailable => 'Already in your library';
@@ -2106,7 +2142,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabRequestErrorValidation => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorUserNotFound => 'Token user no longer exists. Reconnect ReadMeABook.';
+  String get rmabRequestErrorUserNotFound =>
+      'Token user no longer exists. Reconnect ReadMeABook.';
 
   @override
   String get rmabRequestErrorIgnored => 'This book is on your ignore list';
@@ -2115,7 +2152,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabRequestErrorGeneric => 'Couldn\'t send the request';
 
   @override
-  String get rmabRequestErrorTokenRejected => 'Token rejected by server. Reconnect ReadMeABook.';
+  String get rmabRequestErrorTokenRejected =>
+      'Token rejected by server. Reconnect ReadMeABook.';
 
   @override
   String get rmabMyRequestsTab => 'My Requests';
@@ -2142,13 +2180,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rmabApprovalsError => 'Couldn\'t load approvals';
 
   @override
-  String get rmabApprovalForbidden => 'This token isn\'t allowed to review approvals';
+  String get rmabApprovalForbidden =>
+      'This token isn\'t allowed to review approvals';
 
   @override
   String get rmabApprovalNotifsTitle => 'Approval notifications';
 
   @override
-  String get rmabApprovalNotifsSubtitle => 'Notify me when new requests need approval. Best-effort in the background.';
+  String get rmabApprovalNotifsSubtitle =>
+      'Notify me when new requests need approval. Best-effort in the background.';
 
   @override
   String get rmabApprovalNotifsDenied => 'Notification permission was denied';
@@ -2365,7 +2405,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get encodeTimeNote => 'Encoding can take up to 30 minutes.';
 
   @override
-  String get encodeRescanNote => 'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
+  String get encodeRescanNote =>
+      'If you have the watcher disabled you will need to re-scan this audiobook afterwards.';
 
   @override
   String get aboutSection => '关于';
@@ -2766,7 +2807,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get deleteCollectionFailed => 'Couldn\'t delete the collection';
 
   @override
-  String get deletePermissionRequired => 'Delete permission required. Ask the root admin to grant you the delete permission.';
+  String get deletePermissionRequired =>
+      'Delete permission required. Ask the root admin to grant you the delete permission.';
 
   @override
   String get playlistNotFound => '未找到播放列表';
@@ -2843,13 +2885,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get welcomeGettingAroundTitle => '界面操作';
 
   @override
-  String get welcomeGettingAroundBody => '点击任意封面打开详情。继续收听卡片不一样 - 点击立即播放，长按打开详情。';
+  String get welcomeGettingAroundBody =>
+      '点击任意封面打开详情。继续收听卡片不一样 - 点击立即播放，长按打开详情。';
 
   @override
   String get welcomeMakeItYoursTitle => '个性化设置';
 
   @override
-  String get welcomeMakeItYoursBody => '在设置中自定义 Absorb 以符合你的喜好。其中的「技巧与隐藏功能」区块值得一看。';
+  String get welcomeMakeItYoursBody =>
+      '在设置中自定义 Absorb 以符合你的喜好。其中的「技巧与隐藏功能」区块值得一看。';
 
   @override
   String get getStarted => '开始使用';
@@ -2939,7 +2983,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get coverPlayPauseOnSubtitle => 'On - tap cover art to play/pause';
 
   @override
-  String get coverPlayPauseOffSubtitle => 'Off - dedicated play/pause button in controls';
+  String get coverPlayPauseOffSubtitle =>
+      'Off - dedicated play/pause button in controls';
 
   @override
   String get cardBackground => 'Card background';
@@ -2951,7 +2996,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get cardBackgroundGradient => 'Gradient';
 
   @override
-  String get queueModeMergedSubtitle => 'Playback stops, manual queue, or auto-plays next item';
+  String get queueModeMergedSubtitle =>
+      'Playback stops, manual queue, or auto-plays next item';
 
   @override
   String get queueModeSeriesLabel => 'Series';
@@ -2963,13 +3009,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get queueModeInfoSeries => 'Series';
 
   @override
-  String get queueModeInfoSeriesDesc => 'Automatically plays the next book in a series or the next episode in a podcast show.';
+  String get queueModeInfoSeriesDesc =>
+      'Automatically plays the next book in a series or the next episode in a podcast show.';
 
   @override
   String get resetButtonGridQuestion => 'Reset button grid?';
 
   @override
-  String get resetButtonGridContent => 'This will restore the default button layout, order, and toggle settings.';
+  String get resetButtonGridContent =>
+      'This will restore the default button layout, order, and toggle settings.';
 
   @override
   String get reset => 'Reset';
@@ -2987,13 +3035,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterBarrierInfoTitle => 'Chapter barrier';
 
   @override
-  String get chapterBarrierInfoContent => 'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
+  String get chapterBarrierInfoContent =>
+      'When skipping back, the playback will snap to the start of the current chapter instead of crossing into the previous one.\n\nDouble-tap the skip back button within 2 seconds to break through the barrier.';
 
   @override
-  String get chapterBarrierOnRewindOnSubtitle => 'On - rewind snaps to chapter start';
+  String get chapterBarrierOnRewindOnSubtitle =>
+      'On - rewind snaps to chapter start';
 
   @override
-  String get chapterBarrierOnRewindOffSubtitle => 'Off - rewind crosses chapter boundaries';
+  String get chapterBarrierOnRewindOffSubtitle =>
+      'Off - rewind crosses chapter boundaries';
 
   @override
   String autoRewindOnSubtitleFormat(String min, String max) {
@@ -3004,7 +3055,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rewindOnSessionStart => 'Rewind on session start';
 
   @override
-  String get rewindOnSessionStartInfoContent => 'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
+  String get rewindOnSessionStartInfoContent =>
+      'Normal auto-rewind triggers when you resume from a pause within an active session. This setting adds a rewind when starting a completely new session - for example after the app was closed, playback was stopped, or you open the app fresh.\n\nWhen enabled, playback rewinds by the full max rewind amount at the start of every new session so you can re-hear where you left off.';
 
   @override
   String rewindOnSessionStartOnSubtitle(String seconds) {
@@ -3058,7 +3110,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chimeBeforeSleep => 'Chime before sleep';
 
   @override
-  String get chimeBeforeSleepOnSubtitle => 'Plays a gentle bell when the timer is about to end';
+  String get chimeBeforeSleepOnSubtitle =>
+      'Plays a gentle bell when the timer is about to end';
 
   @override
   String get chimeBeforeSleepOffSubtitle => 'No sound warning before sleep';
@@ -3077,7 +3130,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String autoSleepTimerEnabledSubtitle(String start, String end, String duration) {
+  String autoSleepTimerEnabledSubtitle(
+      String start, String end, String duration) {
     return '$start – $end · $duration';
   }
 
@@ -3094,7 +3148,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showExplicitBadge => 'Show explicit badge';
 
   @override
-  String get showExplicitBadgeOnSubtitle => 'Explicit items show an \"E\" badge';
+  String get showExplicitBadgeOnSubtitle =>
+      'Explicit items show an \"E\" badge';
 
   @override
   String get showExplicitBadgeOffSubtitle => 'Off - explicit badge hidden';
@@ -3106,13 +3161,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get preReleaseUpdatesInfoTitle => 'Pre-release Updates';
 
   @override
-  String get preReleaseUpdatesInfoContent => 'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
+  String get preReleaseUpdatesInfoContent =>
+      'When enabled, the update checker will also notify you about alpha and pre-release builds from GitHub. These may be less stable but include the latest features and fixes.';
 
   @override
   String get includePreReleases => 'Include pre-releases';
 
   @override
-  String get includePreReleasesOnSubtitle => 'On - checking for alpha & pre-release builds';
+  String get includePreReleasesOnSubtitle =>
+      'On - checking for alpha & pre-release builds';
 
   @override
   String get includePreReleasesOffSubtitle => 'Off - stable releases only';
@@ -3153,7 +3210,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get updateDownloading => 'Downloading update...';
 
   @override
-  String get updateInstallPermissionDenied => 'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
+  String get updateInstallPermissionDenied =>
+      'Install permission denied. Enable \"Install unknown apps\" for Absorb in system settings.';
 
   @override
   String get updateOpeningInBrowser => 'In-app update failed, opening browser';
@@ -3307,7 +3365,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get backupDetailsSeparator => ' · ';
 
   @override
-  String get bookmarksSortedByPositionReversed => 'Sorted by position (reversed)';
+  String get bookmarksSortedByPositionReversed =>
+      'Sorted by position (reversed)';
 
   @override
   String bookmarksJumpShortContent(String title, String position) {
@@ -3386,7 +3445,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get resetMayNotHaveSynced => 'Reset may not have synced - check your server';
+  String get resetMayNotHaveSynced =>
+      'Reset may not have synced - check your server';
 
   @override
   String failedToDownloadEbook(int code) {
@@ -3394,7 +3454,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get serverReturnedErrorPage => 'Server returned an error page instead of the ebook file';
+  String get serverReturnedErrorPage =>
+      'Server returned an error page instead of the ebook file';
 
   @override
   String ebookSaved(String filename) {
@@ -3694,10 +3755,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminPodcastsCheckNewEpisodesTitle => 'Check for New Episodes';
 
   @override
-  String get adminPodcastsCheckNewEpisodesContent => 'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
+  String get adminPodcastsCheckNewEpisodesContent =>
+      'This will check RSS feeds for all podcasts and download any new episodes found (if auto-download is enabled).';
 
   @override
-  String get adminPodcastsCheckNewEpisodesSubtitle => 'Scan RSS feed and download new episodes';
+  String get adminPodcastsCheckNewEpisodesSubtitle =>
+      'Scan RSS feed and download new episodes';
 
   @override
   String get adminPodcastsCheck => 'Check';
@@ -3967,7 +4030,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get adminPodcastsFailedToCheckNew => 'Failed to check for new episodes';
+  String get adminPodcastsFailedToCheckNew =>
+      'Failed to check for new episodes';
 
   @override
   String get adminPodcastsCheckAndDownload => 'Check & Download';
@@ -3976,19 +4040,24 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminPodcastsMatchPodcast => 'Match Podcast';
 
   @override
-  String get adminPodcastsMatchPodcastSubtitle => 'Search iTunes to update cover and metadata';
+  String get adminPodcastsMatchPodcastSubtitle =>
+      'Search iTunes to update cover and metadata';
 
   @override
-  String get adminPodcastsAutoDownloadNewEpisodes => 'Auto-Download New Episodes';
+  String get adminPodcastsAutoDownloadNewEpisodes =>
+      'Auto-Download New Episodes';
 
   @override
-  String get adminPodcastsAutoDownloadOnSubtitle => 'Server downloads new episodes automatically';
+  String get adminPodcastsAutoDownloadOnSubtitle =>
+      'Server downloads new episodes automatically';
 
   @override
-  String get adminPodcastsAutoDownloadOffSubtitle => 'New episodes are not auto-downloaded';
+  String get adminPodcastsAutoDownloadOffSubtitle =>
+      'New episodes are not auto-downloaded';
 
   @override
-  String get adminPodcastsFailedAutoDownloadUpdate => 'Failed to update auto-download setting';
+  String get adminPodcastsFailedAutoDownloadUpdate =>
+      'Failed to update auto-download setting';
 
   @override
   String get adminPodcastsCheckSchedule => 'Check Schedule';
@@ -4098,7 +4167,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get episodeListUnsubscribeFromNewEpisodes => 'Unsubscribe from New Episodes';
+  String get episodeListUnsubscribeFromNewEpisodes =>
+      'Unsubscribe from New Episodes';
 
   @override
   String get episodeListSubscribeToNewEpisodes => 'Subscribe to New Episodes';
@@ -4107,7 +4177,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get episodeListSubscribeTitle => 'Subscribe to this podcast?';
 
   @override
-  String get episodeListSubscribeContent => 'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
+  String get episodeListSubscribeContent =>
+      'New episodes will be automatically downloaded and added to your absorbing queue when they appear on the server.';
 
   @override
   String get episodeListSubscribe => 'Subscribe';
@@ -4176,10 +4247,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get episodeDetailMarkedFinishedNice => 'Marked as finished - nice!';
 
   @override
-  String get episodeDetailMarkAbsorbedContent => 'This will set your progress to 100% for this episode.';
+  String get episodeDetailMarkAbsorbedContent =>
+      'This will set your progress to 100% for this episode.';
 
   @override
-  String get episodeDetailResetProgressContent => 'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
+  String get episodeDetailResetProgressContent =>
+      'This will erase all progress for this episode and set it back to the beginning. This can\'t be undone.';
 
   @override
   String get episodeDetailToday => 'Today';
@@ -4240,17 +4313,20 @@ class AppLocalizationsZh extends AppLocalizations {
   String get seriesBooksFindMissingTitle => 'Find Missing Books';
 
   @override
-  String get seriesBooksFindMissingContent => 'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
+  String get seriesBooksFindMissingContent =>
+      'This searches Audible to find books in this series that may be missing from your library.\n\nBooks are matched by ASIN first (depending on whether your server has ASINs for its books), then falls back to title matching. Results may not be perfectly accurate.';
 
   @override
-  String get seriesBooksCouldNotFindOnAudible => 'Could not find this series on Audible';
+  String get seriesBooksCouldNotFindOnAudible =>
+      'Could not find this series on Audible';
 
   @override
   String seriesBooksMarkAllNotFinishedContent(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'This will clear the finished status for all $count books in this series.',
+      other:
+          'This will clear the finished status for all $count books in this series.',
       one: 'This will clear the finished status for the 1 book in this series.',
     );
     return '$_temp0';
@@ -4402,7 +4478,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get sessionDeleteConfirmTitle => 'Delete session?';
 
   @override
-  String get sessionDeleteConfirmBody => 'This removes the session and lowers your listening totals by its time. It cannot be undone.';
+  String get sessionDeleteConfirmBody =>
+      'This removes the session and lowers your listening totals by its time. It cannot be undone.';
 
   @override
   String get sessionSaved => 'Session updated';
@@ -4470,7 +4547,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get statsScreenPmLabel => 'PM';
 
   @override
-  String statsScreenDateAtTime(String month, int day, int year, int hour, String minute, String ampm) {
+  String statsScreenDateAtTime(
+      String month, int day, int year, int hour, String minute, String ampm) {
     return '$month $day, $year at $hour:$minute $ampm';
   }
 
@@ -4583,7 +4661,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get upcomingReleasesNoneFound => 'No upcoming or recent releases found';
+  String get upcomingReleasesNoneFound =>
+      'No upcoming or recent releases found';
 
   @override
   String upcomingReleasesAcrossSeries(String summary, int count) {
@@ -4685,7 +4764,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String audibleSeriesSummaryWithUpcoming(int total, int missing, int upcoming) {
+  String audibleSeriesSummaryWithUpcoming(
+      int total, int missing, int upcoming) {
     return '$total on Audible · $missing missing · $upcoming upcoming';
   }
 
@@ -4834,7 +4914,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get librarySortFilterUpcomingReleases => 'Upcoming Releases';
 
   @override
-  String get librarySortFilterUpcomingReleasesSubtitle => 'Scan Audible for new releases in your series';
+  String get librarySortFilterUpcomingReleasesSubtitle =>
+      'Scan Audible for new releases in your series';
 
   @override
   String sleepTimerSheetChaptersLeft(int count) {
@@ -5031,7 +5112,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get homeCustomizeAddGenreTitle => 'Add Genre Section';
 
   @override
-  String get homeCustomizeAddGenreSubtitle => 'Pick a genre to show on your home screen';
+  String get homeCustomizeAddGenreSubtitle =>
+      'Pick a genre to show on your home screen';
 
   @override
   String get homeSectionDoneBadge => 'Done';
@@ -5040,121 +5122,141 @@ class AppLocalizationsZh extends AppLocalizations {
   String get tipsSheetQuickBookmarksTitle => 'Quick Bookmarks';
 
   @override
-  String get tipsSheetQuickBookmarksDesc => 'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
+  String get tipsSheetQuickBookmarksDesc =>
+      'Long-press the bookmark button on any card to instantly drop a bookmark at your current position without opening the bookmark sheet.';
 
   @override
   String get tipsSheetCoverPlayPauseTitle => 'Cover Play/Pause';
 
   @override
-  String get tipsSheetCoverPlayPauseDesc => 'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
+  String get tipsSheetCoverPlayPauseDesc =>
+      'Tap the cover art on any card to play or pause. Toggle this in Settings under Absorbing Cards. A faint pause icon shows when playing so you know it\'s tappable.';
 
   @override
   String get tipsSheetFullScreenPlayerTitle => 'Full Screen Player';
 
   @override
-  String get tipsSheetFullScreenPlayerDesc => 'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
+  String get tipsSheetFullScreenPlayerDesc =>
+      'Swipe up on any absorbing card to open the full screen player. Swipe down to dismiss it.';
 
   @override
   String get tipsSheetQuickAddAbsorbingTitle => 'Quick Add to Absorbing';
 
   @override
-  String get tipsSheetQuickAddAbsorbingDesc => 'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
+  String get tipsSheetQuickAddAbsorbingDesc =>
+      'Swipe right on any book in a list sheet (series, author, search results) to instantly add it to your absorbing queue.';
 
   @override
   String get tipsSheetShakeExtendSleepTitle => 'Shake to Extend Sleep';
 
   @override
-  String get tipsSheetShakeExtendSleepDesc => 'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
+  String get tipsSheetShakeExtendSleepDesc =>
+      'If you have a sleep timer running and shake your phone, it\'ll add extra minutes. Configure the amount in Settings under Sleep Timer.';
 
   @override
   String get tipsSheetSeriesNavigationTitle => 'Series Navigation';
 
   @override
-  String get tipsSheetSeriesNavigationDesc => 'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
+  String get tipsSheetSeriesNavigationDesc =>
+      'Tap the series name in any book\'s detail popup to see all books in the series, sorted in reading order with sequence badges on each cover.';
 
   @override
   String get tipsSheetSwipeBetweenBooksTitle => 'Swipe Between Books';
 
   @override
-  String get tipsSheetSwipeBetweenBooksDesc => 'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
+  String get tipsSheetSwipeBetweenBooksDesc =>
+      'Swipe left and right on the Absorbing screen to switch between your in-progress books. With Manual queue mode on, the cards also act as your queue, so the next one auto-plays when the current one finishes.';
 
   @override
   String get tipsSheetTapToSeekTitle => 'Tap to Seek';
 
   @override
-  String get tipsSheetTapToSeekDesc => 'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
+  String get tipsSheetTapToSeekDesc =>
+      'Tap anywhere on the chapter or book progress bar to jump directly to that position. You can also drag the bars for fine-grained control.';
 
   @override
   String get tipsSheetSpeedAdjustedTimeTitle => 'Speed-Adjusted Time';
 
   @override
-  String get tipsSheetSpeedAdjustedTimeDesc => 'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
+  String get tipsSheetSpeedAdjustedTimeDesc =>
+      'Time remaining and chapter times automatically adjust based on your playback speed. Listening at 1.5x? The time shown reflects how long it\'ll actually take you.';
 
   @override
   String get tipsSheetPlaybackHistoryTitle => 'Playback History';
 
   @override
-  String get tipsSheetPlaybackHistoryDesc => 'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
+  String get tipsSheetPlaybackHistoryDesc =>
+      'Tap the History button on any card to see a timeline of every play, pause, seek, and speed change. Tap any event to jump back to that position.';
 
   @override
   String get tipsSheetAutoRewindTitle => 'Auto-Rewind';
 
   @override
-  String get tipsSheetAutoRewindDesc => 'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
+  String get tipsSheetAutoRewindDesc =>
+      'When you resume after a pause, Absorb automatically rewinds a few seconds so you don\'t lose your place. The rewind amount scales with how long you were away. Configure it in Settings.';
 
   @override
   String get tipsSheetSeriesQueueModeTitle => 'Series Queue Mode';
 
   @override
-  String get tipsSheetSeriesQueueModeDesc => 'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
+  String get tipsSheetSeriesQueueModeDesc =>
+      'When you finish a book that\'s part of a series, Absorb can automatically play the next book. Set queue mode to \"Series\" in Settings.';
 
   @override
   String get tipsSheetOfflineModeTitle => 'Offline Mode';
 
   @override
-  String get tipsSheetOfflineModeDesc => 'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
+  String get tipsSheetOfflineModeDesc =>
+      'Tap the airplane button on the Absorbing screen to enter offline mode. This stops syncing, saves data, and only shows your downloaded books. Great for flights or low signal areas.';
 
   @override
   String get tipsSheetUpcomingReleasesTitle => 'Upcoming Releases';
 
   @override
-  String get tipsSheetUpcomingReleasesDesc => 'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
+  String get tipsSheetUpcomingReleasesDesc =>
+      'On the Series tab, tap the tab again to open its sort and filter sheet, then choose Upcoming Releases to see new and upcoming books across your series, sorted by release date.';
 
   @override
   String get tipsSheetPerBookEqTitle => 'Per-Book Equalizer';
 
   @override
-  String get tipsSheetPerBookEqDesc => 'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
+  String get tipsSheetPerBookEqDesc =>
+      'Each book remembers its own equalizer settings. Tweak EQ once for a sci-fi epic and the next time you play it, it sounds the same.';
 
   @override
   String get tipsSheetPerBookSpeedTitle => 'Per-Book Speed';
 
   @override
-  String get tipsSheetPerBookSpeedDesc => 'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
+  String get tipsSheetPerBookSpeedDesc =>
+      'Playback speed is saved per book. Run nonfiction at 1.5x and dramatic fiction at 1.0x without setting it every time.';
 
   @override
   String get tipsSheetAutoSleepWindowTitle => 'Auto Sleep Window';
 
   @override
-  String get tipsSheetAutoSleepWindowDesc => 'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
+  String get tipsSheetAutoSleepWindowDesc =>
+      'Pick the hours you usually fall asleep and the sleep timer will start itself when you begin listening in that window.';
 
   @override
   String get tipsSheetSleepFadeChimeTitle => 'Sleep Fade and Chime';
 
   @override
-  String get tipsSheetSleepFadeChimeDesc => 'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
+  String get tipsSheetSleepFadeChimeDesc =>
+      'When the sleep timer ends, audio gradually fades out and an optional chime plays so it doesn\'t cut off mid-sentence.';
 
   @override
   String get tipsSheetCarModeTitle => 'Car Mode';
 
   @override
-  String get tipsSheetCarModeDesc => 'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
+  String get tipsSheetCarModeDesc =>
+      'Tap the car icon to switch to giant-button mode designed for safer use while driving.';
 
   @override
   String get tipsSheetAudibleSeriesTitle => 'Audible Series Discovery';
 
   @override
-  String get tipsSheetAudibleSeriesDesc => 'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
+  String get tipsSheetAudibleSeriesDesc =>
+      'Open a series and use the overflow menu (the three dots) to pull the full series list from Audible, including missing entries and books you haven\'t started.';
 
   @override
   String get bookCardUnknownTitle => 'Unknown Title';
@@ -5307,7 +5409,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authInvalidApiKey => 'Invalid API key';
 
   @override
-  String get authLoginFailedDetail => 'Login failed - check your server address and credentials';
+  String get authLoginFailedDetail =>
+      'Login failed - check your server address and credentials';
 
   @override
   String get authUnexpectedServerResponse => 'Unexpected server response';
@@ -5372,13 +5475,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get downloadNotifProgressChannelName => 'Download Progress';
 
   @override
-  String get downloadNotifProgressChannelDesc => 'Shows progress during audiobook downloads';
+  String get downloadNotifProgressChannelDesc =>
+      'Shows progress during audiobook downloads';
 
   @override
   String get downloadNotifAlertChannelName => 'Download Alerts';
 
   @override
-  String get downloadNotifAlertChannelDesc => 'Notifications when downloads finish or fail';
+  String get downloadNotifAlertChannelDesc =>
+      'Notifications when downloads finish or fail';
 
   @override
   String get downloadNotifDownloadingTitle => 'Downloading…';
@@ -5417,7 +5522,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get upcomingNotifChannelName => 'Upcoming Release Scan';
 
   @override
-  String get upcomingNotifChannelDesc => 'Shows progress while scanning for upcoming releases';
+  String get upcomingNotifChannelDesc =>
+      'Shows progress while scanning for upcoming releases';
 
   @override
   String get upcomingNotifScanTitle => 'Scanning for upcoming releases';
@@ -5426,7 +5532,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get upcomingNotifStartingScan => 'Starting scan…';
 
   @override
-  String upcomingNotifCheckingSeries(String seriesName, int current, int total) {
+  String upcomingNotifCheckingSeries(
+      String seriesName, int current, int total) {
     return 'Checking $seriesName… ($current/$total)';
   }
 
@@ -5496,7 +5603,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authorRemoveImageTitle => 'Remove author image?';
 
   @override
-  String get authorRemoveImageConfirm => 'This deletes the image on the server.';
+  String get authorRemoveImageConfirm =>
+      'This deletes the image on the server.';
 
   @override
   String get authorImageRemoved => 'Image removed';
@@ -5522,7 +5630,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get authorQuickMatchHint => 'Pull name, ASIN, description and image from Audible for the chosen region.';
+  String get authorQuickMatchHint =>
+      'Pull name, ASIN, description and image from Audible for the chosen region.';
 
   @override
   String get region => 'Region';
@@ -5549,7 +5658,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterErrorFirstNotZero => 'First chapter must start at 0:00';
 
   @override
-  String get chapterErrorStartAfterPrevious => 'Start must come after the previous chapter';
+  String get chapterErrorStartAfterPrevious =>
+      'Start must come after the previous chapter';
 
   @override
   String get chapterErrorStartBeforeEnd => 'Start must be before the book ends';
@@ -5624,7 +5734,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterRemoveAllTitle => 'Remove all chapters?';
 
   @override
-  String get chapterRemoveAllMessage => 'This removes every chapter from this book.';
+  String get chapterRemoveAllMessage =>
+      'This removes every chapter from this book.';
 
   @override
   String get chapterAllRemoved => 'All chapters removed';
@@ -5666,7 +5777,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterShiftBySeconds => 'Shift by (seconds)';
 
   @override
-  String get chapterShiftHint => 'Shifts every unlocked chapter. Use a negative value to move them earlier.';
+  String get chapterShiftHint =>
+      'Shifts every unlocked chapter. Use a negative value to move them earlier.';
 
   @override
   String get chapterBack1Second => 'Back 1 second';
@@ -5710,7 +5822,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get chapterFindTitle => 'Find chapters';
 
   @override
-  String get chapterFindSubtitle => 'Looks up chapters from Audible/Audnexus by ASIN.';
+  String get chapterFindSubtitle =>
+      'Looks up chapters from Audible/Audnexus by ASIN.';
 
   @override
   String get chapterEnterAsin => 'Enter an ASIN';
@@ -5735,10 +5848,12 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get chapterAudibleLonger => 'The Audible version is longer than your file - later chapters may not line up.';
+  String get chapterAudibleLonger =>
+      'The Audible version is longer than your file - later chapters may not line up.';
 
   @override
-  String get chapterAudibleShorter => 'The Audible version is shorter than your file - chapters may not line up.';
+  String get chapterAudibleShorter =>
+      'The Audible version is shorter than your file - chapters may not line up.';
 
   @override
   String get chapterTitlesOnly => 'Titles only';
@@ -5750,7 +5865,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get coverSearchTitle => 'Search for a cover';
 
   @override
-  String get coverSearchRefineHint => 'Refine the title/author to clean up results - this does not change the book.';
+  String get coverSearchRefineHint =>
+      'Refine the title/author to clean up results - this does not change the book.';
 
   @override
   String get coverNoneFound => 'No covers found';
@@ -5771,19 +5887,23 @@ class AppLocalizationsZh extends AppLocalizations {
   String get coverUnknownResolution => 'Unknown resolution';
 
   @override
-  String get embedIntro => 'Embed metadata into audio files including cover image and chapters.';
+  String get embedIntro =>
+      'Embed metadata into audio files including cover image and chapters.';
 
   @override
   String get embedBackupOption => 'Back up audio files first';
 
   @override
-  String get embedNoteInFolder => 'Metadata will be embedded in the audio tracks inside your audiobook folder.';
+  String get embedNoteInFolder =>
+      'Metadata will be embedded in the audio tracks inside your audiobook folder.';
 
   @override
-  String get embedNoteMultiTrack => 'Chapters are not embedded in multi-track audiobooks.';
+  String get embedNoteMultiTrack =>
+      'Chapters are not embedded in multi-track audiobooks.';
 
   @override
-  String get embedNoteNavigateAway => 'Once the task is started you can navigate away from this page.';
+  String get embedNoteNavigateAway =>
+      'Once the task is started you can navigate away from this page.';
 
   @override
   String get embedStartButton => 'Start Metadata Embed';
@@ -5805,7 +5925,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get taskStarting => 'Starting...';
 
   @override
-  String get embedBackupNoteIntro => 'A backup of your original audio files will be stored on the server in ';
+  String get embedBackupNoteIntro =>
+      'A backup of your original audio files will be stored on the server in ';
 
   @override
   String embedBackupNotePath(String itemId) {
@@ -5813,7 +5934,8 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get embedBackupNoteOutro => '. Make sure to periodically purge the items cache.';
+  String get embedBackupNoteOutro =>
+      '. Make sure to periodically purge the items cache.';
 
   @override
   String get embedDialogTitle => 'Embed metadata';
@@ -5904,7 +6026,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminApiKeysTokenLabel => 'Your new API key';
 
   @override
-  String get adminApiKeysCopyWarning => 'Copy this key now. For security it won\'t be shown again.';
+  String get adminApiKeysCopyWarning =>
+      'Copy this key now. For security it won\'t be shown again.';
 
   @override
   String get adminApiKeysCopy => 'Copy';
@@ -5943,7 +6066,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminApiKeysEmpty => 'No API keys yet';
 
   @override
-  String get adminApiKeysEmptySub => 'Create one to let apps and scripts reach your server';
+  String get adminApiKeysEmptySub =>
+      'Create one to let apps and scripts reach your server';
 
   @override
   String get adminApiKeysNeverUsed => 'Never used';
@@ -6036,7 +6160,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminAllSessions => 'All sessions';
 
   @override
-  String get adminAllSessionsSubtitle => 'View and manage all listening sessions';
+  String get adminAllSessionsSubtitle =>
+      'View and manage all listening sessions';
 
   @override
   String get adminSessionsAllUsers => 'All users';
@@ -6177,7 +6302,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libDeleteTitle => 'Delete library?';
 
   @override
-  String get libDeleteBody => 'This permanently removes the library and all of its items from the server.';
+  String get libDeleteBody =>
+      'This permanently removes the library and all of its items from the server.';
 
   @override
   String get libDeleted => 'Library deleted';
@@ -6299,5 +6425,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libRemoveFoldersTitle => 'Remove folders?';
 
   @override
-  String get libRemoveFoldersBody => 'Removing a folder deletes its items from the library. This can\'t be undone.';
+  String get libRemoveFoldersBody =>
+      'Removing a folder deletes its items from the library. This can\'t be undone.';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'services/sleep_timer_service.dart';
 import 'services/scoped_prefs.dart';
 import 'services/user_account_service.dart';
 import 'services/android_auto_service.dart';
+import 'services/rmab_approvals_notifier.dart';
 import 'services/carplay_service.dart';
 import 'services/chromecast_service.dart';
 import 'services/home_widget_service.dart';
@@ -146,6 +147,9 @@ void applyUseColorEverywhere(bool value) => useColorEverywhereNotifier.value = v
 void main() async {
   HttpOverrides.global = _CertOverrides();
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+
+  // Register the RMAB approvals background entry-point early (Android headless).
+  RmabApprovalsNotifier.registerHeadless();
 
   // These calls use platform channels that require an Activity. When Android
   // Auto cold-starts the app for the MediaBrowserService, no Activity exists

--- a/lib/screens/app_shell.dart
+++ b/lib/screens/app_shell.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import '../providers/library_provider.dart';
 import '../services/audio_player_service.dart';
 import '../services/chromecast_service.dart';
+import '../services/rmab_approvals_notifier.dart';
 import '../services/home_widget_service.dart';
 import '../services/sleep_timer_service.dart';
 import 'dart:io';
@@ -325,6 +326,8 @@ class _AppShellState extends State<AppShell> with WidgetsBindingObserver, Ticker
     context.read<LibraryProvider>().addListener(_onLibraryChanged);
     WelcomeSheet.showIfNeeded(context);
     _checkForUpdate();
+    // Best-effort RMAB approval notifications (opt-in; no-op when disabled).
+    RmabApprovalsNotifier.init();
   }
 
   static const _isGithubBuild = bool.fromEnvironment('GITHUB_BUILD');

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -38,6 +38,7 @@ import '../widgets/feature_hint.dart';
 import '../widgets/welcome_sheet.dart';
 import '../widgets/rmab_config_sheet.dart';
 import '../services/rmab_service.dart';
+import '../services/rmab_approvals_notifier.dart';
 import '../l10n/app_localizations.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -146,6 +147,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String? _rmabBaseUrl;
   String? _rmabApiToken;
   int _rmabPendingApprovals = 0;
+  bool _rmabIsAdmin = false;
+  bool _rmabApprovalNotifs = false;
   bool _loaded = false;
   String _downloadLocationLabel = 'App Internal Storage (Default)';
   bool _canPickDownloadLocation = false;
@@ -781,6 +784,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _loaded = true;
     });
     _refreshRmabApprovalsBadge();
+    RmabApprovalsNotifier.isEnabled().then((v) {
+      if (mounted) setState(() => _rmabApprovalNotifs = v);
+    });
   }
 
   static const _shakeSensitivityKeys = ['veryLow', 'low', 'medium', 'high', 'veryHigh'];
@@ -3030,6 +3036,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       trailing: Icon(Icons.chevron_right_rounded, color: cs.onSurfaceVariant.withValues(alpha: 0.5)),
                       onTap: _openRmabSheetFromSettings,
                     ),
+                    if (_rmabIsAdmin) ...[
+                      const Divider(height: 1, indent: 16, endIndent: 16),
+                      SwitchListTile(
+                        secondary: Icon(Icons.notifications_active_outlined,
+                            color: cs.primary),
+                        title: Text(l.rmabApprovalNotifsTitle),
+                        subtitle: Text(l.rmabApprovalNotifsSubtitle,
+                            style: tt.bodySmall
+                                ?.copyWith(color: cs.onSurfaceVariant)),
+                        value: _rmabApprovalNotifs,
+                        onChanged:
+                            _loaded ? _toggleRmabApprovalNotifs : null,
+                      ),
+                    ],
                   ],
                 ),
                 const SizedBox(height: 16),
@@ -3885,8 +3905,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
     final token = await ScopedPrefs.getString(kRmabApiTokenKey);
     if (base == null || base.isEmpty || token == null || token.isEmpty) {
-      if (mounted && _rmabPendingApprovals != 0) {
-        setState(() => _rmabPendingApprovals = 0);
+      if (mounted && (_rmabPendingApprovals != 0 || _rmabIsAdmin)) {
+        setState(() {
+          _rmabPendingApprovals = 0;
+          _rmabIsAdmin = false;
+        });
       }
       return;
     }
@@ -3894,14 +3917,50 @@ class _SettingsScreenState extends State<SettingsScreen> {
       final pending = await RmabService(baseUrl: base, apiToken: token)
           .listPendingApprovals();
       if (!mounted) return;
-      if (_rmabPendingApprovals != pending.length) {
-        setState(() => _rmabPendingApprovals = pending.length);
+      setState(() {
+        _rmabPendingApprovals = pending.length;
+        _rmabIsAdmin = true;
+      });
+    } on RmabException catch (e) {
+      if (!mounted) return;
+      // A user-scoped token can't see approvals (403) — hide badge + toggle.
+      // Other errors (network, etc.) just clear the count and leave admin as-is.
+      if (e.kind == RmabErrorKind.forbidden) {
+        setState(() {
+          _rmabPendingApprovals = 0;
+          _rmabIsAdmin = false;
+        });
+      } else if (_rmabPendingApprovals != 0) {
+        setState(() => _rmabPendingApprovals = 0);
       }
+      debugPrint('[RMAB] approvals badge refresh skipped: ${e.kind}');
     } catch (e) {
-      debugPrint('[RMAB] approvals badge refresh skipped: $e');
+      debugPrint('[RMAB] approvals badge refresh error: $e');
       if (mounted && _rmabPendingApprovals != 0) {
         setState(() => _rmabPendingApprovals = 0);
       }
+    }
+  }
+
+  Future<void> _toggleRmabApprovalNotifs(bool enable) async {
+    final l = AppLocalizations.of(context)!;
+    if (enable) {
+      final ok = await RmabApprovalsNotifier.enable();
+      if (!mounted) return;
+      if (!ok) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(l.rmabApprovalNotifsDenied),
+          behavior: SnackBarBehavior.floating,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ));
+        return;
+      }
+      setState(() => _rmabApprovalNotifs = true);
+    } else {
+      await RmabApprovalsNotifier.disable();
+      if (!mounted) return;
+      setState(() => _rmabApprovalNotifs = false);
     }
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -37,6 +37,7 @@ import '../widgets/tips_sheet.dart';
 import '../widgets/feature_hint.dart';
 import '../widgets/welcome_sheet.dart';
 import '../widgets/rmab_config_sheet.dart';
+import '../services/rmab_service.dart';
 import '../l10n/app_localizations.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -144,6 +145,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _includePreReleases = false;
   String? _rmabBaseUrl;
   String? _rmabApiToken;
+  int _rmabPendingApprovals = 0;
   bool _loaded = false;
   String _downloadLocationLabel = 'App Internal Storage (Default)';
   bool _canPickDownloadLocation = false;
@@ -778,6 +780,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
       _loaded = true;
     });
+    _refreshRmabApprovalsBadge();
   }
 
   static const _shakeSensitivityKeys = ['veryLow', 'low', 'medium', 'high', 'veryHigh'];
@@ -3010,12 +3013,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     ],
                     const Divider(height: 1, indent: 16, endIndent: 16),
                     ListTile(
-                      leading: Icon(Icons.menu_book_rounded, color: cs.primary),
+                      leading: _rmabPendingApprovals > 0
+                          ? Badge.count(
+                              count: _rmabPendingApprovals,
+                              child: Icon(Icons.menu_book_rounded, color: cs.primary),
+                            )
+                          : Icon(Icons.menu_book_rounded, color: cs.primary),
                       title: Text(l.adminRmab),
                       subtitle: Text(
-                        ((_rmabBaseUrl ?? '').isNotEmpty && (_rmabApiToken ?? '').isNotEmpty)
-                            ? l.adminRmabConnected
-                            : l.adminRmabAskAdmin,
+                        _rmabPendingApprovals > 0
+                            ? l.adminRmabApprovalsPending(_rmabPendingApprovals)
+                            : ((_rmabBaseUrl ?? '').isNotEmpty && (_rmabApiToken ?? '').isNotEmpty)
+                                ? l.adminRmabConnected
+                                : l.adminRmabAskAdmin,
                         style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
                       trailing: Icon(Icons.chevron_right_rounded, color: cs.onSurfaceVariant.withValues(alpha: 0.5)),
                       onTap: _openRmabSheetFromSettings,
@@ -3845,7 +3855,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final isAdmin = context.read<AuthProvider>().isAdmin;
     final result =
         await showRmabConfigSheet(context, isAdminContext: isAdmin);
-    if (!mounted || result == null) return;
+    if (!mounted) return;
+    // Approvals may have been acted on (or creds changed) while the drawer
+    // was open — re-fetch the badge count regardless of the result.
+    _refreshRmabApprovalsBadge();
+    if (result == null) return;
     if (result.changed || result.disconnected) {
       final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
       final token = await ScopedPrefs.getString(kRmabApiTokenKey);
@@ -3861,6 +3875,33 @@ class _SettingsScreenState extends State<SettingsScreen> {
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       ));
+    }
+  }
+
+  /// Fetch the pending-approval count for the RMAB tile badge. The endpoint is
+  /// admin-only, so a successful response doubles as the admin check — a
+  /// non-admin token (forbidden) or any error simply clears the badge.
+  Future<void> _refreshRmabApprovalsBadge() async {
+    final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
+    final token = await ScopedPrefs.getString(kRmabApiTokenKey);
+    if (base == null || base.isEmpty || token == null || token.isEmpty) {
+      if (mounted && _rmabPendingApprovals != 0) {
+        setState(() => _rmabPendingApprovals = 0);
+      }
+      return;
+    }
+    try {
+      final pending = await RmabService(baseUrl: base, apiToken: token)
+          .listPendingApprovals();
+      if (!mounted) return;
+      if (_rmabPendingApprovals != pending.length) {
+        setState(() => _rmabPendingApprovals = pending.length);
+      }
+    } catch (e) {
+      debugPrint('[RMAB] approvals badge refresh skipped: $e');
+      if (mounted && _rmabPendingApprovals != 0) {
+        setState(() => _rmabPendingApprovals = 0);
+      }
     }
   }
 

--- a/lib/services/rmab_approvals_notifier.dart
+++ b/lib/services/rmab_approvals_notifier.dart
@@ -1,0 +1,260 @@
+import 'dart:async';
+
+import 'package:background_fetch/background_fetch.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../l10n/app_localizations.dart';
+import '../main.dart' show rootNavigatorKey;
+import '../widgets/rmab_config_sheet.dart';
+import 'rmab_service.dart';
+import 'scoped_prefs.dart';
+
+/// Best-effort background notifier for RMAB admin approvals.
+///
+/// On a periodic background-fetch tick it polls `listPendingApprovals()` and
+/// fires a local notification when *new* requests have appeared since the last
+/// check. Tapping the notification opens the RMAB drawer on the Approvals tab.
+///
+/// iOS background execution is heavily throttled by the OS, so delivery is
+/// best-effort — not guaranteed or timely. The feature is opt-in (default off);
+/// the dependable surface is the in-app badge ([_refreshRmabApprovalsBadge] in
+/// settings) and the Approvals tab itself.
+class RmabApprovalsNotifier {
+  RmabApprovalsNotifier._();
+
+  /// ScopedPrefs key: '`true`' when the user has opted in.
+  static const String enabledKey = 'rmab_approval_notifs';
+
+  /// ScopedPrefs key: comma-joined request ids already seen (the baseline we
+  /// diff against, so we only notify for genuinely new requests).
+  static const String _seenIdsKey = 'rmab_seen_approval_ids';
+
+  static const String _payload = 'rmab_approvals';
+  static const int _notifId = 920411;
+  static const String _channelId = 'rmab_approvals';
+  static const String _channelName = 'ReadMeABook approvals';
+
+  static final FlutterLocalNotificationsPlugin _fln =
+      FlutterLocalNotificationsPlugin();
+  static bool _notifReady = false;
+  static bool _configured = false;
+
+  static Future<bool> isEnabled() async =>
+      (await ScopedPrefs.getString(enabledKey)) == 'true';
+
+  /// Register the Android headless entry-point. Call once, as early as possible
+  /// in `main()` (no-op on iOS).
+  static void registerHeadless() {
+    try {
+      BackgroundFetch.registerHeadlessTask(rmabApprovalsHeadlessTask);
+    } catch (e) {
+      debugPrint('[RMAB] registerHeadless failed: $e');
+    }
+  }
+
+  /// One-time app-start setup: init notifications, handle a cold-start tap, and
+  /// configure background-fetch (started only if the user opted in).
+  static Future<void> init() async {
+    await _ensureNotifications();
+
+    // Cold start launched by tapping the notification.
+    final launch = await _fln.getNotificationAppLaunchDetails();
+    if (launch?.didNotificationLaunchApp == true &&
+        launch?.notificationResponse?.payload == _payload) {
+      _navigateToApprovals();
+    }
+
+    await _configureBackgroundFetch();
+  }
+
+  static Future<void> _ensureNotifications() async {
+    if (_notifReady) return;
+    const android = AndroidInitializationSettings('ic_notification');
+    const darwin = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+    await _fln.initialize(
+      const InitializationSettings(android: android, iOS: darwin),
+      onDidReceiveNotificationResponse: (resp) {
+        if (resp.payload == _payload) _navigateToApprovals();
+      },
+    );
+    _notifReady = true;
+  }
+
+  static Future<void> _configureBackgroundFetch() async {
+    if (_configured) return;
+    _configured = true;
+    try {
+      await BackgroundFetch.configure(
+        BackgroundFetchConfig(
+          minimumFetchInterval: 15,
+          stopOnTerminate: false,
+          startOnBoot: true,
+          enableHeadless: true,
+          requiredNetworkType: NetworkType.ANY,
+        ),
+        (String taskId) async {
+          await _poll();
+          BackgroundFetch.finish(taskId);
+        },
+        (String taskId) async {
+          // OS-imposed task timeout — must finish promptly.
+          BackgroundFetch.finish(taskId);
+        },
+      );
+      if (await isEnabled()) {
+        await BackgroundFetch.start();
+      } else {
+        await BackgroundFetch.stop();
+      }
+    } catch (e) {
+      debugPrint('[RMAB] background_fetch configure failed: $e');
+    }
+  }
+
+  /// Opt in: request OS permission, persist, seed the baseline (so the current
+  /// backlog doesn't notify immediately), and start background fetch.
+  /// Returns false if the OS notification permission was denied.
+  static Future<bool> enable() async {
+    await _ensureNotifications();
+    final granted = await _requestPermission();
+    if (!granted) return false;
+    await ScopedPrefs.setString(enabledKey, 'true');
+    await _poll(seedOnly: true);
+    await _configureBackgroundFetch();
+    try {
+      await BackgroundFetch.start();
+    } catch (e) {
+      debugPrint('[RMAB] background_fetch start failed: $e');
+    }
+    return true;
+  }
+
+  /// Opt out: persist, stop background fetch, clear any showing notification.
+  static Future<void> disable() async {
+    await ScopedPrefs.setString(enabledKey, 'false');
+    try {
+      await BackgroundFetch.stop();
+    } catch (_) {}
+    try {
+      await _fln.cancel(_notifId);
+    } catch (_) {}
+  }
+
+  static Future<bool> _requestPermission() async {
+    try {
+      final ios = _fln.resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin>();
+      if (ios != null) {
+        return (await ios.requestPermissions(
+                alert: true, badge: true, sound: true)) ??
+            false;
+      }
+      final android = _fln.resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>();
+      if (android != null) {
+        return (await android.requestNotificationsPermission()) ?? true;
+      }
+    } catch (e) {
+      debugPrint('[RMAB] notif permission error: $e');
+    }
+    return true;
+  }
+
+  /// Fetch pending approvals and notify on ids not seen before. [seedOnly]
+  /// records the baseline without notifying (used on opt-in).
+  static Future<void> _poll({bool seedOnly = false}) async {
+    if (!seedOnly && !(await isEnabled())) return;
+    final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
+    final token = await ScopedPrefs.getString(kRmabApiTokenKey);
+    if (base == null || base.isEmpty || token == null || token.isEmpty) return;
+
+    final List<RmabPendingApproval> pending;
+    try {
+      pending = await RmabService(baseUrl: base, apiToken: token)
+          .listPendingApprovals();
+    } catch (e) {
+      // 403 (non-admin), network, etc. — nothing to do this tick.
+      debugPrint('[RMAB] approvals poll skipped: $e');
+      return;
+    }
+
+    final currentIds = pending.map((e) => e.id).toSet();
+    final seen = await _loadSeen();
+    final newOnes = pending.where((e) => !seen.contains(e.id)).toList();
+
+    await _saveSeen(currentIds);
+    if (seedOnly || newOnes.isEmpty) return;
+    await _notify(newOnes);
+  }
+
+  static Future<void> _notify(List<RmabPendingApproval> newOnes) async {
+    final ctx = rootNavigatorKey.currentContext;
+    final l = ctx != null ? AppLocalizations.of(ctx) : null;
+    final count = newOnes.length;
+    final title = l?.rmabApprovalNotifTitle ?? 'Approvals waiting';
+    final body = count == 1
+        ? (l?.rmabApprovalNotifBodyOne(newOnes.first.audiobook.title) ??
+            '"${newOnes.first.audiobook.title}" needs your approval')
+        : (l?.rmabApprovalNotifBodyMany(count) ??
+            '$count requests need your approval');
+
+    const android = AndroidNotificationDetails(
+      _channelId,
+      _channelName,
+      channelDescription: 'New ReadMeABook requests awaiting your approval',
+      importance: Importance.high,
+      priority: Priority.high,
+      icon: 'ic_notification',
+    );
+    const ios = DarwinNotificationDetails();
+    await _fln.show(
+      _notifId,
+      title,
+      body,
+      const NotificationDetails(android: android, iOS: ios),
+      payload: _payload,
+    );
+  }
+
+  static Future<Set<String>> _loadSeen() async {
+    final raw = await ScopedPrefs.getString(_seenIdsKey);
+    if (raw == null || raw.isEmpty) return <String>{};
+    return raw.split(',').where((s) => s.isNotEmpty).toSet();
+  }
+
+  static Future<void> _saveSeen(Set<String> ids) async {
+    await ScopedPrefs.setString(_seenIdsKey, ids.join(','));
+  }
+
+  /// Open the RMAB drawer on the Approvals tab. Retries briefly so it also
+  /// works from a cold start, before the navigator is mounted.
+  static Future<void> _navigateToApprovals() async {
+    for (var i = 0; i < 20; i++) {
+      final ctx = rootNavigatorKey.currentContext;
+      if (ctx != null) {
+        await showRmabConfigSheet(ctx,
+            isAdminContext: true, initialApprovals: true);
+        return;
+      }
+      await Future.delayed(const Duration(milliseconds: 250));
+    }
+  }
+}
+
+/// Android headless entry-point (fires when the app is terminated). iOS does
+/// not use this path. Kept self-contained so it works in its own isolate.
+@pragma('vm:entry-point')
+void rmabApprovalsHeadlessTask(HeadlessTask task) async {
+  if (task.timeout) {
+    BackgroundFetch.finish(task.taskId);
+    return;
+  }
+  await RmabApprovalsNotifier._ensureNotifications();
+  await RmabApprovalsNotifier._poll();
+  BackgroundFetch.finish(task.taskId);
+}

--- a/lib/services/rmab_service.dart
+++ b/lib/services/rmab_service.dart
@@ -237,6 +237,78 @@ class RmabService {
     }
   }
 
+  // ─── /api/admin/requests/pending-approval ───────────────────────
+
+  /// GET /api/admin/requests/pending-approval — admin-only list of requests
+  /// in `awaiting_approval`. Requires an admin-scoped token; a user token
+  /// gets [RmabErrorKind.forbidden].
+  Future<List<RmabPendingApproval>> listPendingApprovals() async {
+    debugPrint('[RMAB] listPendingApprovals()');
+    final uri = Uri.parse('$baseUrl/api/admin/requests/pending-approval');
+    final res = await _get(uri, label: 'pendingApprovals');
+    final out = _decode(res, (json) {
+      return (json['requests'] as List<dynamic>? ?? [])
+          .whereType<Map<String, dynamic>>()
+          .map(RmabPendingApproval.fromJson)
+          .toList();
+    }, label: 'pendingApprovals');
+    debugPrint('[RMAB] listPendingApprovals() -> ${out.length} pending');
+    return out;
+  }
+
+  // ─── /api/admin/requests/:id/approve ────────────────────────────
+
+  /// POST /api/admin/requests/:id/approve — approve or deny a pending request.
+  /// Admin-only. Returns the updated request on success.
+  ///
+  /// Throws [RmabException]: `forbidden` (not admin / token not allowed),
+  /// `unauthorized`, `network`, or `server` (the latter carries the server's
+  /// message, e.g. the 400 "no longer awaiting approval" stale case).
+  Future<RmabRequest> respondToApproval(String id,
+      {required bool approve}) async {
+    final action = approve ? 'approve' : 'deny';
+    debugPrint('[RMAB] respondToApproval(id=$id action=$action)');
+    final uri = Uri.parse('$baseUrl/api/admin/requests/$id/approve');
+    final http.Response res;
+    try {
+      res = await http
+          .post(uri,
+              headers: _headers, body: jsonEncode({'action': action}))
+          .timeout(const Duration(seconds: 20));
+      debugPrint('[RMAB] respondToApproval <- ${res.statusCode} '
+          '(${res.body.length} bytes)');
+    } on TimeoutException {
+      throw RmabException(RmabErrorKind.network, 'Request timed out');
+    } on SocketException catch (e) {
+      throw RmabException(RmabErrorKind.network, e.message);
+    } on http.ClientException catch (e) {
+      throw RmabException(RmabErrorKind.network, e.message);
+    } catch (e) {
+      throw RmabException(RmabErrorKind.network, e.toString());
+    }
+
+    if (res.statusCode == 401) {
+      throw RmabException(RmabErrorKind.unauthorized,
+          _safeServerMessage(res) ?? 'Unauthorized');
+    }
+    if (res.statusCode == 403) {
+      throw RmabException(RmabErrorKind.forbidden,
+          _safeServerMessage(res) ?? 'Forbidden');
+    }
+    if (res.statusCode == 200) {
+      return _decode(res, (json) {
+        final req = json['request'];
+        if (req is! Map<String, dynamic>) {
+          throw const FormatException('Response missing "request"');
+        }
+        return RmabRequest.fromJson(req);
+      }, label: 'respondToApproval');
+    }
+    // 400 InvalidStatus/ValidationError, 404 NotFound, 5xx — surface message.
+    throw RmabException(RmabErrorKind.server,
+        _safeServerMessage(res) ?? 'Server returned HTTP ${res.statusCode}');
+  }
+
   // ─── Shared helpers ─────────────────────────────────────────────
 
   Future<http.Response> _get(Uri uri, {required String label}) async {
@@ -621,6 +693,60 @@ class RmabRequestCounts {
   final int completed;
   final int failed;
   final int cancelled;
+}
+
+// ─── pending-approval models ──────────────────────────────────────
+
+/// A request awaiting admin approval, as returned by
+/// GET /api/admin/requests/pending-approval. Unlike [RmabRequest], this
+/// carries the requesting user so an admin can see who asked for it.
+class RmabPendingApproval {
+  RmabPendingApproval({
+    required this.id,
+    required this.createdAt,
+    required this.audiobook,
+    required this.requester,
+  });
+
+  final String id;
+  final DateTime createdAt;
+  final RmabAudiobookSummary audiobook;
+  final RmabApprovalRequester requester;
+
+  factory RmabPendingApproval.fromJson(Map<String, dynamic> json) {
+    final book = json['audiobook'] as Map<String, dynamic>?;
+    final user = json['user'] as Map<String, dynamic>?;
+    return RmabPendingApproval(
+      id: (json['id'] ?? '') as String,
+      createdAt: _asDate(json['createdAt']) ?? DateTime.now(),
+      audiobook: book != null
+          ? RmabAudiobookSummary.fromJson(book)
+          : RmabAudiobookSummary.empty(),
+      requester: RmabApprovalRequester.fromJson(user ?? const {}),
+    );
+  }
+}
+
+/// The user behind a pending request. `username` comes from the server's
+/// `plexUsername`; `avatarUrl` may be null.
+class RmabApprovalRequester {
+  RmabApprovalRequester({
+    required this.id,
+    required this.username,
+    this.avatarUrl,
+  });
+
+  final String id;
+  final String username;
+  final String? avatarUrl;
+
+  factory RmabApprovalRequester.fromJson(Map<String, dynamic> json) =>
+      RmabApprovalRequester(
+        id: (json['id'] ?? '') as String,
+        username:
+            (json['plexUsername'] ?? json['username'] ?? '') as String,
+        avatarUrl: json['avatarUrl'] as String?,
+      );
 }
 
 // ─── createRequest models ─────────────────────────────────────────

--- a/lib/services/rmab_service.dart
+++ b/lib/services/rmab_service.dart
@@ -133,7 +133,7 @@ class RmabService {
   /// GET /api/requests/:id — full detail for a single request.
   Future<RmabRequest> getRequest(String id) async {
     debugPrint('[RMAB] getRequest(id=$id)');
-    final uri = Uri.parse('$baseUrl/api/requests/$id');
+    final uri = Uri.parse('$baseUrl/api/requests/${Uri.encodeComponent(id)}');
     final res = await _get(uri, label: 'getRequest');
     final out = _decode(res, (json) {
       final req = json['request'];
@@ -268,7 +268,7 @@ class RmabService {
       {required bool approve}) async {
     final action = approve ? 'approve' : 'deny';
     debugPrint('[RMAB] respondToApproval(id=$id action=$action)');
-    final uri = Uri.parse('$baseUrl/api/admin/requests/$id/approve');
+    final uri = Uri.parse('$baseUrl/api/admin/requests/${Uri.encodeComponent(id)}/approve');
     final http.Response res;
     try {
       res = await http

--- a/lib/widgets/rmab_config_sheet.dart
+++ b/lib/widgets/rmab_config_sheet.dart
@@ -1344,7 +1344,7 @@ class _ApprovalsTabState extends State<_ApprovalsTab>
           child: Row(children: [
             Expanded(
               child: Text(
-                _items == null ? '' : _countLabel(_items!.length),
+                _items == null ? '' : l.adminRmabApprovalsPending(_items!.length),
                 style:
                     tt.labelMedium?.copyWith(color: cs.onSurfaceVariant),
               ),
@@ -1360,9 +1360,6 @@ class _ApprovalsTabState extends State<_ApprovalsTab>
       ],
     );
   }
-
-  String _countLabel(int n) =>
-      n == 1 ? '1 awaiting approval' : '$n awaiting approval';
 
   Widget _buildBody(ColorScheme cs, TextTheme tt, AppLocalizations l) {
     if (_loading) {

--- a/lib/widgets/rmab_config_sheet.dart
+++ b/lib/widgets/rmab_config_sheet.dart
@@ -289,6 +289,10 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
     setState(() => _obscureToken = !_obscureToken);
   }
 
+  void _demoteFromAdmin() {
+    setState(() => _isRmabAdmin = false);
+  }
+
   Future<void> _disconnect() async {
     debugPrint('[RMAB] disconnect: clearing all rmab_* keys + local cache');
     await ScopedPrefs.remove(kRmabBaseUrlKey);
@@ -419,7 +423,10 @@ class _ConfiguredView extends StatelessWidget {
         scrollController: scrollController,
       ),
       if (showApprovals)
-        _ApprovalsTab(key: ValueKey('approvals-$credsVersion')),
+        _ApprovalsTab(
+          key: ValueKey('approvals-$credsVersion'),
+          onForbidden: state._demoteFromAdmin,
+        ),
       _SetupTab(state: state),
     ];
 
@@ -1171,7 +1178,9 @@ class _RequestDetailSheet extends StatelessWidget {
 // ─── Approvals tab (admin-only) ──────────────────────────────────
 
 class _ApprovalsTab extends StatefulWidget {
-  const _ApprovalsTab({super.key});
+  const _ApprovalsTab({super.key, this.onForbidden});
+
+  final VoidCallback? onForbidden;
 
   @override
   State<_ApprovalsTab> createState() => _ApprovalsTabState();
@@ -1232,6 +1241,11 @@ class _ApprovalsTabState extends State<_ApprovalsTab>
     } on RmabException catch (e) {
       if (!mounted) return;
       debugPrint('[RMAB] approvals error: ${e.kind} ${e.message}');
+      if (e.kind == RmabErrorKind.forbidden) {
+        ScopedPrefs.setString(kRmabRoleKey, 'user');
+        widget.onForbidden?.call();
+        return;
+      }
       setState(() {
         _error = _msgForException(e);
         _loading = false;

--- a/lib/widgets/rmab_config_sheet.dart
+++ b/lib/widgets/rmab_config_sheet.dart
@@ -43,6 +43,7 @@ class RmabConfigResult {
 Future<RmabConfigResult?> showRmabConfigSheet(
   BuildContext context, {
   required bool isAdminContext,
+  bool initialApprovals = false,
 }) {
   return showStackableSheet<RmabConfigResult>(
     context: context,
@@ -53,6 +54,7 @@ Future<RmabConfigResult?> showRmabConfigSheet(
     useSafeArea: true,
     builder: (ctx, scrollController) => _RmabConfigSheet(
       isAdminContext: isAdminContext,
+      initialApprovals: initialApprovals,
       scrollController: scrollController,
     ),
   );
@@ -62,9 +64,11 @@ class _RmabConfigSheet extends StatefulWidget {
   const _RmabConfigSheet({
     required this.isAdminContext,
     required this.scrollController,
+    this.initialApprovals = false,
   });
 
   final bool isAdminContext;
+  final bool initialApprovals;
   final ScrollController scrollController;
 
   @override
@@ -333,6 +337,7 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
       return _ConfiguredView(
         state: this,
         credsVersion: _credsVersion,
+        initialApprovals: widget.initialApprovals,
         scrollController: widget.scrollController,
       );
     }
@@ -385,9 +390,11 @@ class _ConfiguredView extends StatelessWidget {
     required this.state,
     required this.credsVersion,
     required this.scrollController,
+    this.initialApprovals = false,
   });
   final _RmabConfigSheetState state;
   final int credsVersion;
+  final bool initialApprovals;
   final ScrollController scrollController;
 
   @override
@@ -422,6 +429,7 @@ class _ConfiguredView extends StatelessWidget {
     // bubbles up to the sheet for dismissal.
     return DefaultTabController(
       length: tabs.length,
+      initialIndex: (showApprovals && initialApprovals) ? 1 : 0,
       child: Column(
         children: [
           Padding(

--- a/lib/widgets/rmab_config_sheet.dart
+++ b/lib/widgets/rmab_config_sheet.dart
@@ -14,6 +14,10 @@ import 'stackable_sheet.dart';
 const String kRmabBaseUrlKey = 'rmab_base_url';
 const String kRmabApiTokenKey = 'rmab_api_token';
 
+/// Cached RMAB role ('admin' | 'user') of the connected token, captured at
+/// connect time. Drives whether the admin-only Approvals tab is shown.
+const String kRmabRoleKey = 'rmab_role';
+
 /// Legacy single-URL key. Still read so existing WebView-only users keep
 /// working, and so the "Open in browser view" action prefers their
 /// embedded-token URL when present.
@@ -79,6 +83,7 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
   bool _connecting = false;
   bool _obscureToken = true;
   bool _wasConfigured = false;
+  bool _isRmabAdmin = false;
   String? _legacyUrl;
   String? _errorText;
   String? _connectedAsName;
@@ -97,6 +102,7 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
     final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
     final token = await ScopedPrefs.getString(kRmabApiTokenKey);
     final legacy = await ScopedPrefs.getString(kRmabLegacyUrlKey);
+    final role = await ScopedPrefs.getString(kRmabRoleKey);
 
     // Migration: if the new base URL isn't set but a legacy URL is, try to
     // extract just the origin so the user only needs to paste a token.
@@ -110,15 +116,38 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
     }
 
     if (!mounted) return;
+    final configured = (base ?? '').isNotEmpty && (token ?? '').isNotEmpty;
     setState(() {
       _urlController.text = prefilledBase;
       _tokenController.text = token ?? '';
       _legacyUrlController.text = legacy ?? '';
       _legacyUrl = legacy;
-      _wasConfigured =
-          (base ?? '').isNotEmpty && (token ?? '').isNotEmpty;
+      _wasConfigured = configured;
+      _isRmabAdmin = role == 'admin';
       _loadingPrefs = false;
     });
+
+    // Backfill the role for users who connected before role caching existed
+    // (configured, but no stored role). Fail closed (non-admin) on error.
+    if (configured && role == null) {
+      _backfillRole();
+    }
+  }
+
+  /// Fetch the connected token's role via `me()` and cache it. Reveals the
+  /// admin-only Approvals tab without requiring a reconnect.
+  Future<void> _backfillRole() async {
+    final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
+    final token = await ScopedPrefs.getString(kRmabApiTokenKey);
+    if (base == null || base.isEmpty || token == null || token.isEmpty) return;
+    try {
+      final me = await RmabService(baseUrl: base, apiToken: token).me();
+      await ScopedPrefs.setString(kRmabRoleKey, me.role);
+      if (!mounted) return;
+      setState(() => _isRmabAdmin = me.isAdmin);
+    } catch (e) {
+      debugPrint('[RMAB] role backfill failed: $e');
+    }
   }
 
   @override
@@ -177,6 +206,7 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
 
       await ScopedPrefs.setString(kRmabBaseUrlKey, cleanBase);
       await ScopedPrefs.setString(kRmabApiTokenKey, token);
+      await ScopedPrefs.setString(kRmabRoleKey, me.role);
       // Legacy URL handling depends on context:
       //   Admin: respect whatever they typed in the legacy URL field.
       //     Non-empty → save it. Empty → clear it. Gives admins explicit
@@ -212,6 +242,7 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
         _connecting = false;
         _connectedAsName = me.username;
         _wasConfigured = true;
+        _isRmabAdmin = me.isAdmin;
         _credsVersion++;
         _legacyUrl = refreshedLegacy;
       });
@@ -256,6 +287,7 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
     await ScopedPrefs.remove(kRmabBaseUrlKey);
     await ScopedPrefs.remove(kRmabApiTokenKey);
     await ScopedPrefs.remove(kRmabLegacyUrlKey);
+    await ScopedPrefs.remove(kRmabRoleKey);
     RmabLocalRequestCache.clear();
     if (!mounted) return;
     Navigator.of(context).pop(const RmabConfigResult(disconnected: true));
@@ -360,12 +392,33 @@ class _ConfiguredView extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final l = AppLocalizations.of(context)!;
 
+    // Approvals is admin-only. The sheet's [scrollController] can attach to a
+    // single scroll view at a time, and My Requests already owns it, so the
+    // Approvals tab uses its own internal controller.
+    final showApprovals = state._isRmabAdmin;
+
+    final tabs = <Tab>[
+      Tab(text: l.rmabMyRequestsTab),
+      if (showApprovals) Tab(text: l.rmabApprovalsTab),
+      Tab(text: l.rmabSetupTab),
+    ];
+    final views = <Widget>[
+      _MyRequestsTab(
+        key: ValueKey('myrequests-$credsVersion'),
+        state: state,
+        scrollController: scrollController,
+      ),
+      if (showApprovals)
+        _ApprovalsTab(key: ValueKey('approvals-$credsVersion')),
+      _SetupTab(state: state),
+    ];
+
     // No fixed SizedBox height here — the parent DraggableScrollableSheet
     // (via showStackableSheet) supplies the bounded space. The My Requests
     // tab's ListView uses [scrollController] so drag-down-when-at-top
     // bubbles up to the sheet for dismissal.
     return DefaultTabController(
-      length: 2,
+      length: tabs.length,
       child: Column(
         children: [
           Padding(
@@ -377,23 +430,9 @@ class _ConfiguredView extends StatelessWidget {
             labelColor: cs.primary,
             unselectedLabelColor: cs.onSurfaceVariant,
             indicatorColor: cs.primary,
-            tabs: [
-              Tab(text: l.rmabMyRequestsTab),
-              Tab(text: l.rmabSetupTab),
-            ],
+            tabs: tabs,
           ),
-          Expanded(
-            child: TabBarView(
-              children: [
-                _MyRequestsTab(
-                  key: ValueKey('myrequests-$credsVersion'),
-                  state: state,
-                  scrollController: scrollController,
-                ),
-                _SetupTab(state: state),
-              ],
-            ),
-          ),
+          Expanded(child: TabBarView(children: views)),
         ],
       ),
     );
@@ -1115,5 +1154,440 @@ class _RequestDetailSheet extends StatelessWidget {
     final l = dt.toLocal();
     return '${l.year}-${two(l.month)}-${two(l.day)} '
         '${two(l.hour)}:${two(l.minute)}';
+  }
+}
+
+// ─── Approvals tab (admin-only) ──────────────────────────────────
+
+class _ApprovalsTab extends StatefulWidget {
+  const _ApprovalsTab({super.key});
+
+  @override
+  State<_ApprovalsTab> createState() => _ApprovalsTabState();
+}
+
+class _ApprovalsTabState extends State<_ApprovalsTab>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  // Own controller (not the sheet's shared one) — see _ConfiguredView.
+  final _scrollController = ScrollController();
+
+  bool _loading = true;
+  String? _error;
+  List<RmabPendingApproval>? _items;
+
+  /// Ids currently being approved/denied — drives per-row spinners and guards
+  /// against double taps.
+  final Set<String> _acting = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _fetch() async {
+    debugPrint('[RMAB] approvals tab fetching');
+    final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
+    final token = await ScopedPrefs.getString(kRmabApiTokenKey);
+    if (!mounted) return;
+    if (base == null || base.isEmpty || token == null || token.isEmpty) {
+      setState(() {
+        _loading = false;
+        _error = AppLocalizations.of(context)!.rmabConfigErrorUnauthorized;
+      });
+      return;
+    }
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final items = await RmabService(baseUrl: base, apiToken: token)
+          .listPendingApprovals();
+      if (!mounted) return;
+      setState(() {
+        _items = items;
+        _loading = false;
+      });
+    } on RmabException catch (e) {
+      if (!mounted) return;
+      debugPrint('[RMAB] approvals error: ${e.kind} ${e.message}');
+      setState(() {
+        _error = _msgForException(e);
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      debugPrint('[RMAB] approvals unexpected: $e');
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  String _msgForException(RmabException e) {
+    final l = AppLocalizations.of(context)!;
+    switch (e.kind) {
+      case RmabErrorKind.forbidden:
+        return l.rmabApprovalForbidden;
+      case RmabErrorKind.unauthorized:
+        return l.rmabRequestErrorTokenRejected;
+      case RmabErrorKind.network:
+        return l.rmabConfigErrorNetwork;
+      default:
+        return '${l.rmabApprovalsError}: ${e.message}';
+    }
+  }
+
+  Future<void> _act(RmabPendingApproval item, {required bool approve}) async {
+    if (_acting.contains(item.id)) return;
+    final l = AppLocalizations.of(context)!;
+    final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
+    final token = await ScopedPrefs.getString(kRmabApiTokenKey);
+    if (!mounted) return;
+    if (base == null || base.isEmpty || token == null || token.isEmpty) return;
+    setState(() => _acting.add(item.id));
+    try {
+      await RmabService(baseUrl: base, apiToken: token)
+          .respondToApproval(item.id, approve: approve);
+      if (!mounted) return;
+      setState(() {
+        _items?.removeWhere((e) => e.id == item.id);
+        _acting.remove(item.id);
+      });
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(approve ? l.rmabApprovalApproved : l.rmabApprovalDenied),
+      ));
+    } on RmabException catch (e) {
+      if (!mounted) return;
+      setState(() => _acting.remove(item.id));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(_msgForException(e))));
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _acting.remove(item.id));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(e.toString())));
+    }
+  }
+
+  Future<void> _confirmDeny(RmabPendingApproval item) async {
+    final l = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l.rmabApprovalDenyConfirmTitle),
+        content: Text(l.rmabApprovalDenyConfirmBody(item.audiobook.title)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: cs.error),
+            child: Text(l.rmabApprovalDeny),
+          ),
+        ],
+      ),
+    );
+    if (ok == true) await _act(item, approve: false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final l = AppLocalizations.of(context)!;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 8, 8, 4),
+          child: Row(children: [
+            Expanded(
+              child: Text(
+                _items == null ? '' : _countLabel(_items!.length),
+                style:
+                    tt.labelMedium?.copyWith(color: cs.onSurfaceVariant),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.refresh_rounded),
+              tooltip: l.rmabMyRequestsRefresh,
+              onPressed: _loading ? null : _fetch,
+            ),
+          ]),
+        ),
+        Expanded(child: _buildBody(cs, tt, l)),
+      ],
+    );
+  }
+
+  String _countLabel(int n) =>
+      n == 1 ? '1 awaiting approval' : '$n awaiting approval';
+
+  Widget _buildBody(ColorScheme cs, TextTheme tt, AppLocalizations l) {
+    if (_loading) {
+      return ListView(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(24, 80, 24, 24),
+        children: const [
+          Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        ],
+      );
+    }
+    if (_error != null) {
+      return ListView(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(24, 60, 24, 24),
+        children: [
+          Icon(Icons.error_outline_rounded, size: 40, color: cs.error),
+          const SizedBox(height: 12),
+          Center(
+            child: Text(
+              _error!,
+              textAlign: TextAlign.center,
+              style: tt.bodyMedium?.copyWith(color: cs.error),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Center(
+            child: TextButton.icon(
+              icon: const Icon(Icons.refresh_rounded, size: 18),
+              label: Text(l.rmabMyRequestsRefresh),
+              onPressed: _fetch,
+            ),
+          ),
+        ],
+      );
+    }
+    final items = _items ?? const <RmabPendingApproval>[];
+    if (items.isEmpty) {
+      return ListView(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(24, 60, 24, 24),
+        children: [
+          Icon(Icons.inbox_rounded,
+              size: 40, color: cs.onSurfaceVariant.withValues(alpha: 0.5)),
+          const SizedBox(height: 12),
+          Center(
+            child: Text(
+              l.rmabApprovalsEmpty,
+              textAlign: TextAlign.center,
+              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+            ),
+          ),
+        ],
+      );
+    }
+    return ListView.builder(
+      controller: _scrollController,
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: EdgeInsets.fromLTRB(
+          16, 4, 16, 16 + MediaQuery.of(context).viewPadding.bottom),
+      itemCount: items.length,
+      itemBuilder: (_, i) => _ApprovalRow(
+        item: items[i],
+        acting: _acting.contains(items[i].id),
+        onApprove: () => _act(items[i], approve: true),
+        onDeny: () => _confirmDeny(items[i]),
+      ),
+    );
+  }
+}
+
+class _ApprovalRow extends StatelessWidget {
+  const _ApprovalRow({
+    required this.item,
+    required this.acting,
+    required this.onApprove,
+    required this.onDeny,
+  });
+
+  final RmabPendingApproval item;
+  final bool acting;
+  final VoidCallback onApprove;
+  final VoidCallback onDeny;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final l = AppLocalizations.of(context)!;
+    final book = item.audiobook;
+    final username =
+        item.requester.username.isEmpty ? '—' : item.requester.username;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Material(
+        color: cs.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(12),
+        clipBehavior: Clip.antiAlias,
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: SizedBox(
+                      width: 56,
+                      height: 56,
+                      child: (book.coverArtUrl == null ||
+                              book.coverArtUrl!.isEmpty)
+                          ? Container(
+                              color: cs.surfaceContainerHighest,
+                              child: Icon(Icons.menu_book_rounded,
+                                  color: cs.onSurfaceVariant, size: 20),
+                            )
+                          : CachedNetworkImage(
+                              imageUrl: book.coverArtUrl!,
+                              fit: BoxFit.cover,
+                              placeholder: (_, __) => Container(
+                                  color: cs.surfaceContainerHighest),
+                              errorWidget: (_, __, ___) => Container(
+                                color: cs.surfaceContainerHighest,
+                                child: Icon(Icons.broken_image_rounded,
+                                    color: cs.onSurfaceVariant, size: 20),
+                              ),
+                            ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          book.title,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: tt.bodyMedium
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                        if (book.author.isNotEmpty) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            book.author,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: tt.bodySmall
+                                ?.copyWith(color: cs.onSurfaceVariant),
+                          ),
+                        ],
+                        const SizedBox(height: 6),
+                        Row(children: [
+                          _RequesterAvatar(
+                              url: item.requester.avatarUrl, size: 18),
+                          const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              l.rmabApprovalRequestedBy(username),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: tt.labelSmall?.copyWith(
+                                  color: cs.onSurfaceVariant
+                                      .withValues(alpha: 0.8)),
+                            ),
+                          ),
+                        ]),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 36,
+                child: acting
+                    ? const Align(
+                        alignment: Alignment.centerRight,
+                        child: Padding(
+                          padding: EdgeInsets.only(right: 12),
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child:
+                                CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        ),
+                      )
+                    : Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          TextButton.icon(
+                            onPressed: onDeny,
+                            icon: const Icon(Icons.close_rounded, size: 18),
+                            label: Text(l.rmabApprovalDeny),
+                            style: TextButton.styleFrom(
+                                foregroundColor: cs.error),
+                          ),
+                          const SizedBox(width: 8),
+                          FilledButton.icon(
+                            onPressed: onApprove,
+                            icon: const Icon(Icons.check_rounded, size: 18),
+                            label: Text(l.rmabApprovalApprove),
+                          ),
+                        ],
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RequesterAvatar extends StatelessWidget {
+  const _RequesterAvatar({required this.url, required this.size});
+  final String? url;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    Widget fallback() => Container(
+          width: size,
+          height: size,
+          color: cs.surfaceContainerHighest,
+          child: Icon(Icons.person_rounded,
+              size: size * 0.62, color: cs.onSurfaceVariant),
+        );
+    return ClipOval(
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: (url == null || url!.isEmpty)
+            ? fallback()
+            : CachedNetworkImage(
+                imageUrl: url!,
+                fit: BoxFit.cover,
+                placeholder: (_, __) =>
+                    Container(color: cs.surfaceContainerHighest),
+                errorWidget: (_, __, ___) => fallback(),
+              ),
+      ),
+    );
   }
 }

--- a/lib/widgets/rmab_config_sheet.dart
+++ b/lib/widgets/rmab_config_sheet.dart
@@ -127,16 +127,19 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
       _loadingPrefs = false;
     });
 
-    // Backfill the role for users who connected before role caching existed
-    // (configured, but no stored role). Fail closed (non-admin) on error.
-    if (configured && role == null) {
-      _backfillRole();
+    // Re-verify the role on every open so the Approvals tab tracks the
+    // server: a demoted admin loses it and a promoted user gains it without
+    // reconnecting. The cached role above drives the first frame; this also
+    // covers users who connected before role caching existed (role == null).
+    if (configured) {
+      _refreshRole();
     }
   }
 
-  /// Fetch the connected token's role via `me()` and cache it. Reveals the
-  /// admin-only Approvals tab without requiring a reconnect.
-  Future<void> _backfillRole() async {
+  /// Fetch the connected token's current role via `me()` and cache it, so the
+  /// admin-only Approvals tab reflects the server's current role. Fail closed
+  /// (keep the cached/non-admin value) on error.
+  Future<void> _refreshRole() async {
     final base = await ScopedPrefs.getString(kRmabBaseUrlKey);
     final token = await ScopedPrefs.getString(kRmabApiTokenKey);
     if (base == null || base.isEmpty || token == null || token.isEmpty) return;
@@ -146,7 +149,7 @@ class _RmabConfigSheetState extends State<_RmabConfigSheet> {
       if (!mounted) return;
       setState(() => _isRmabAdmin = me.isAdmin);
     } catch (e) {
-      debugPrint('[RMAB] role backfill failed: $e');
+      debugPrint('[RMAB] role refresh failed: $e');
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -72,6 +72,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.5.5"
+  background_fetch:
+    dependency: "direct main"
+    description:
+      name: background_fetch
+      sha256: a185b471f6ff93c0074e2da98fbdf1e0c5af5a83adb97dfe924a9ef06c9e0175
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.7.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,10 @@ dependencies:
   # Download notifications
   flutter_local_notifications: ^17.2.1
 
+  # Periodic background polling for RMAB approval notifications
+  # (iOS BGTaskScheduler / Android WorkManager). Best-effort on iOS.
+  background_fetch: ^1.3.0
+
   device_info_plus: ^11.0.0
 
   # choose file location


### PR DESCRIPTION
### NOTE:

_I'm keeping this as a draft as it's dependent on ReadMeABook adding the request and approve API calls to the token allowlist. I've got a PR to add it (among other things) [on their GitHub page](https://github.com/kikootwo/ReadMeABook/pull/231), but this feature won't work until it's approved. I'll try to remember to come back and pull it out of draft if/when it's added._

_Also I haven't been able to really put the notifications through their paces, especially on non-iOS platforms. I can cut the notifications stuff from this PR if you'd rather implement proper push notifications later (which this is not). Just lemme know either way._
_____________

## Summary

- Add an **Approvals tab** to the RMAB drawer, visible only to admin-scoped tokens, where admins can review, approve, or deny pending audiobook requests
- **Badge the RMAB settings tile** with a live count of pending approvals so admins notice new requests without opening the drawer
- **Re-verify the admin role** via `me()` each time the drawer opens, so promotions/demotions take effect without reconnecting
- **Opt-in background notifications** (`background_fetch` + `flutter_local_notifications`) that poll for new pending approvals and fire a local notification when new requests appear — tapping the notification opens the drawer directly on the Approvals tab


## Details

**Service Layer** (`rmab_service.dart`):
- `listPendingApprovals()` — GET `/api/admin/requests/pending-approval`
- `respondToApproval(id, approve:)` — POST `/api/admin/requests/:id/approve`
- New models: `RmabPendingApproval`, `RmabApprovalRequester`

**Approvals Tab** (`rmab_config_sheet.dart`):
- Card per request showing cover art, title, author, and requesting user's avatar + username
- Approve (one tap) and Deny (with confirmation dialog) actions, with per-row loading spinners
- Pull-to-refresh, error/empty states

**Background Notifier** (`rmab_approvals_notifier.dart`):
- Opt-in toggle in Settings (only shown to admins)
- Tracks previously-seen request IDs so only genuinely new requests trigger a notification
- Seeds the baseline on opt-in so the existing backlog doesn't fire immediately
- Android headless entry-point for terminated-app execution
- iOS execution is best-effort (OS-throttled); the in-app badge is the reliable surface

**Settings Screen**:
- Pending-approval badge on the RMAB tile (via `_refreshRmabApprovalsBadge`)
- Notification toggle (`SwitchListTile`) conditionally shown for admin tokens
- Badge refreshes both on settings load and when returning from the RMAB drawer

## Screenshot

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/6455c627-a9f6-4234-b228-fd7919876000" />

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/84765cea-37e0-44bd-a44b-6af53a98986d" />

<img width="330" height="300" alt="image" src="https://github.com/user-attachments/assets/078657ae-e9c6-441c-acda-c6b808030a40" />
