### PR TITLE
feat: add Buffer and Threshold sliders for Skip Silence on Android

### DIFF
--- a/android/app/src/main/kotlin/com/barnabas/absorb/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/barnabas/absorb/MainActivity.kt
@@ -24,6 +24,7 @@ import android.view.KeyEvent
 import com.ryanheise.audioservice.AudioService
 import com.ryanheise.audioservice.AudioServiceActivity
 import com.ryanheise.audioservice.AudioServicePlugin
+import com.ryanheise.just_audio.AbsorbSilenceController
 import com.ryanheise.just_audio.MonoController
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterEngineCache
@@ -116,6 +117,13 @@ class MainActivity : AudioServiceActivity() {
                     "setMono" -> {
                         val enabled = call.argument<Boolean>("enabled") ?: false
                         MonoController.setMonoEnabled(enabled)
+                        result.success(true)
+                    }
+                    "setSkipSilence" -> {
+                        val enabled = call.argument<Boolean>("enabled") ?: false
+                        val paddingMs = call.argument<Int>("paddingMs") ?: 20
+                        val thresholdDb = call.argument<Int>("thresholdDb") ?: -30
+                        AbsorbSilenceController.setParameters(enabled, paddingMs, thresholdDb)
                         result.success(true)
                     }
                     else -> result.notImplemented()

--- a/lib/services/audio_player_service.dart
+++ b/lib/services/audio_player_service.dart
@@ -2532,7 +2532,7 @@ class AudioPlayerService extends ChangeNotifier {
       // Wire the EQ service's skip-silence toggle through to just_audio.
       // Android-only: just_audio's setSkipSilenceEnabled is a no-op on iOS.
       if (Platform.isAndroid) {
-        EqualizerService().setSkipSilenceApplier((enabled) {
+        EqualizerService().setSkipSilenceApplier((enabled, paddingMs, thresholdDb) {
           try {
             _handler?.player.setSkipSilenceEnabled(enabled);
           } catch (e) {

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -163,6 +163,8 @@ class BackupService {
       'bands': await ScopedPrefs.getString('eq_bands'),
       'mono': await ScopedPrefs.getBool('eq_mono') ?? false,
       'skipSilence': await ScopedPrefs.getBool('eq_skipSilence') ?? false,
+      'skipSilencePadding': await ScopedPrefs.getInt('eq_skipSilencePadding') ?? 20,
+      'skipSilenceThreshold': await ScopedPrefs.getInt('eq_skipSilenceThreshold') ?? -30,
       'perItem': await ScopedPrefs.getBool('eq_perItem') ?? false,
     };
 
@@ -664,6 +666,8 @@ class BackupService {
       }
       if (eq['mono'] != null) await ScopedPrefs.setBool('eq_mono', eq['mono'] as bool);
       if (eq['skipSilence'] != null) await ScopedPrefs.setBool('eq_skipSilence', eq['skipSilence'] as bool);
+      if (eq['skipSilencePadding'] != null) await ScopedPrefs.setInt('eq_skipSilencePadding', (eq['skipSilencePadding'] as num).toInt());
+      if (eq['skipSilenceThreshold'] != null) await ScopedPrefs.setInt('eq_skipSilenceThreshold', (eq['skipSilenceThreshold'] as num).toInt());
       if (eq['perItem'] != null) await ScopedPrefs.setBool('eq_perItem', eq['perItem'] as bool);
     }
 

--- a/lib/services/equalizer_service.dart
+++ b/lib/services/equalizer_service.dart
@@ -25,14 +25,16 @@ class EqualizerService extends ChangeNotifier {
   double _loudnessGain = 0.0; // 0.0–1.0
   bool _mono = false;
   bool _skipSilence = false;
+  int _skipSilencePadding = 20; // 0–200 ms (default 20 ms)
+  int _skipSilenceThreshold = -30; // -50 to -20 dB (default -30 dB)
   bool _perItem = false;
   String? _currentItemId;
 
   /// Applied to the just_audio AudioPlayer whenever skipSilence changes
-  /// (toggle, per-book switch, account reload). Registered by
+  /// (toggle, padding, threshold, per-book switch, account reload). Registered by
   /// AudioPlayerService.init so the EQ service stays decoupled from
   /// just_audio.
-  void Function(bool enabled)? _skipSilenceApplier;
+  void Function(bool enabled, int paddingMs, int thresholdDb)? _skipSilenceApplier;
 
   /// Invoked when [anyProcessingActive] may have changed so the iOS engine can
   /// attach/detach its processing tap. Registered by AudioPlayerService.
@@ -63,6 +65,8 @@ class EqualizerService extends ChangeNotifier {
   double get loudnessGain => _loudnessGain;
   bool get mono => _mono;
   bool get skipSilence => _skipSilence;
+  int get skipSilencePadding => _skipSilencePadding;
+  int get skipSilenceThreshold => _skipSilenceThreshold;
   bool get perItem => _perItem;
   String? get currentItemId => _currentItemId;
 
@@ -104,7 +108,7 @@ class EqualizerService extends ChangeNotifier {
       debugPrint('[EQ] Unexpected error: $e — using software presets');
       _setupSoftwareFallback();
     }
-    _skipSilenceApplier?.call(_skipSilence);
+    _applySkipSilence();
     _tapApplier?.call(anyProcessingActive);
     notifyListeners();
   }
@@ -200,17 +204,44 @@ class EqualizerService extends ChangeNotifier {
   /// the applier no-ops on iOS.
   Future<void> setSkipSilence(bool value) async {
     _skipSilence = value;
-    _skipSilenceApplier?.call(_skipSilence);
+    _applySkipSilence();
     await _saveSettings();
     notifyListeners();
+  }
+
+  /// Set skip-silence padding in milliseconds (0–200 ms).
+  Future<void> setSkipSilencePadding(int value) async {
+    _skipSilencePadding = value.clamp(0, 200);
+    _applySkipSilence();
+    await _saveSettings();
+    notifyListeners();
+  }
+
+  /// Set skip-silence threshold in dB (-50 to -20 dB).
+  Future<void> setSkipSilenceThreshold(int value) async {
+    _skipSilenceThreshold = value.clamp(-50, -20);
+    _applySkipSilence();
+    await _saveSettings();
+    notifyListeners();
+  }
+
+  void _applySkipSilence() {
+    _skipSilenceApplier?.call(_skipSilence, _skipSilencePadding, _skipSilenceThreshold);
+    try {
+      _channel.invokeMethod('setSkipSilence', {
+        'enabled': _skipSilence,
+        'paddingMs': _skipSilencePadding,
+        'thresholdDb': _skipSilenceThreshold,
+      });
+    } catch (_) {}
   }
 
   /// Register a callback that the service invokes whenever skipSilence
   /// changes. Called once immediately with the current value so the player
   /// picks up persisted state on app start.
-  void setSkipSilenceApplier(void Function(bool enabled) fn) {
+  void setSkipSilenceApplier(void Function(bool enabled, int paddingMs, int thresholdDb) fn) {
     _skipSilenceApplier = fn;
-    fn(_skipSilence);
+    fn(_skipSilence, _skipSilencePadding, _skipSilenceThreshold);
   }
 
   /// Register the iOS processing-tap applier. Called once immediately so the
@@ -240,7 +271,9 @@ class EqualizerService extends ChangeNotifier {
     _loudnessGain = 0.0;
     _mono = false;
     _skipSilence = false;
-    _skipSilenceApplier?.call(_skipSilence);
+    _skipSilencePadding = 20;
+    _skipSilenceThreshold = -30;
+    _applySkipSilence();
     if (_enabled) {
       _applyCurrentSettings();
     } else {
@@ -327,7 +360,7 @@ class EqualizerService extends ChangeNotifier {
     }
     _currentItemId = itemId;
     await _loadItemSettings(itemId);
-    _skipSilenceApplier?.call(_skipSilence);
+    _applySkipSilence();
     if (_enabled) {
       _applyCurrentSettings();
     } else {
@@ -355,6 +388,8 @@ class EqualizerService extends ChangeNotifier {
         'loudnessGain': 0.0,
         'mono': false,
         'skipSilence': false,
+        'skipSilencePadding': 20,
+        'skipSilenceThreshold': -30,
         'bands': List<double>.filled(bandCount, 0.0),
       };
     }
@@ -370,6 +405,8 @@ class EqualizerService extends ChangeNotifier {
       'loudnessGain': await ScopedPrefs.getDouble(_itemKey('loudnessGain', itemId)) ?? 0.0,
       'mono': await ScopedPrefs.getBool(_itemKey('mono', itemId)) ?? false,
       'skipSilence': await ScopedPrefs.getBool(_itemKey('skipSilence', itemId)) ?? false,
+      'skipSilencePadding': await ScopedPrefs.getInt(_itemKey('skipSilencePadding', itemId)) ?? 20,
+      'skipSilenceThreshold': await ScopedPrefs.getInt(_itemKey('skipSilenceThreshold', itemId)) ?? -30,
       'bands': bands,
     };
   }
@@ -383,6 +420,8 @@ class EqualizerService extends ChangeNotifier {
     await ScopedPrefs.setDouble(_itemKey('loudnessGain', itemId), s['loudnessGain'] as double);
     await ScopedPrefs.setBool(_itemKey('mono', itemId), s['mono'] as bool);
     await ScopedPrefs.setBool(_itemKey('skipSilence', itemId), s['skipSilence'] as bool? ?? false);
+    await ScopedPrefs.setInt(_itemKey('skipSilencePadding', itemId), s['skipSilencePadding'] as int? ?? 20);
+    await ScopedPrefs.setInt(_itemKey('skipSilenceThreshold', itemId), s['skipSilenceThreshold'] as int? ?? -30);
     final bands = (s['bands'] as List).cast<double>();
     await ScopedPrefs.setString(_itemKey('bands', itemId), bands.map((l) => l.toStringAsFixed(1)).join(','));
   }
@@ -397,6 +436,8 @@ class EqualizerService extends ChangeNotifier {
       _loudnessGain = 0.0;
       _mono = false;
       _skipSilence = false;
+      _skipSilencePadding = 20;
+      _skipSilenceThreshold = -30;
       _bandLevels = List.filled(_bandLevels.length, 0.0);
       return;
     }
@@ -407,6 +448,8 @@ class EqualizerService extends ChangeNotifier {
     _loudnessGain = await ScopedPrefs.getDouble(_itemKey('loudnessGain', itemId)) ?? 0.0;
     _mono = await ScopedPrefs.getBool(_itemKey('mono', itemId)) ?? false;
     _skipSilence = await ScopedPrefs.getBool(_itemKey('skipSilence', itemId)) ?? false;
+    _skipSilencePadding = await ScopedPrefs.getInt(_itemKey('skipSilencePadding', itemId)) ?? 20;
+    _skipSilenceThreshold = await ScopedPrefs.getInt(_itemKey('skipSilenceThreshold', itemId)) ?? -30;
     final bandStr = await ScopedPrefs.getString(_itemKey('bands', itemId));
     if (bandStr != null) {
       _bandLevels = bandStr.split(',').map((s) => double.tryParse(s) ?? 0.0).toList();
@@ -423,6 +466,8 @@ class EqualizerService extends ChangeNotifier {
     await ScopedPrefs.setDouble(_itemKey('loudnessGain', itemId), _loudnessGain);
     await ScopedPrefs.setBool(_itemKey('mono', itemId), _mono);
     await ScopedPrefs.setBool(_itemKey('skipSilence', itemId), _skipSilence);
+    await ScopedPrefs.setInt(_itemKey('skipSilencePadding', itemId), _skipSilencePadding);
+    await ScopedPrefs.setInt(_itemKey('skipSilenceThreshold', itemId), _skipSilenceThreshold);
     await ScopedPrefs.setString(_itemKey('bands', itemId), _bandLevels.map((l) => l.toStringAsFixed(1)).join(','));
   }
 
@@ -435,6 +480,8 @@ class EqualizerService extends ChangeNotifier {
     _loudnessGain = await ScopedPrefs.getDouble('eq_loudnessGain') ?? 0.0;
     _mono = await ScopedPrefs.getBool('eq_mono') ?? false;
     _skipSilence = await ScopedPrefs.getBool('eq_skipSilence') ?? false;
+    _skipSilencePadding = await ScopedPrefs.getInt('eq_skipSilencePadding') ?? 20;
+    _skipSilenceThreshold = await ScopedPrefs.getInt('eq_skipSilenceThreshold') ?? -30;
 
     final bandStr = await ScopedPrefs.getString('eq_bands');
     if (bandStr != null) {
@@ -452,7 +499,7 @@ class EqualizerService extends ChangeNotifier {
   Future<void> reloadForActiveAccount() async {
     await _loadSettings();
     _currentItemId = null;
-    _skipSilenceApplier?.call(_skipSilence);
+    _applySkipSilence();
     if (_enabled) {
       await _applyCurrentSettings();
     } else {
@@ -470,6 +517,8 @@ class EqualizerService extends ChangeNotifier {
     await ScopedPrefs.setDouble('eq_loudnessGain', _loudnessGain);
     await ScopedPrefs.setBool('eq_mono', _mono);
     await ScopedPrefs.setBool('eq_skipSilence', _skipSilence);
+    await ScopedPrefs.setInt('eq_skipSilencePadding', _skipSilencePadding);
+    await ScopedPrefs.setInt('eq_skipSilenceThreshold', _skipSilenceThreshold);
     await ScopedPrefs.setString('eq_bands', _bandLevels.map((l) => l.toStringAsFixed(1)).join(','));
     if (_perItem && _currentItemId != null) {
       await _saveItemSettings(_currentItemId!);

--- a/lib/widgets/equalizer_sheet.dart
+++ b/lib/widgets/equalizer_sheet.dart
@@ -59,6 +59,8 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
   double _pBass = 0.0, _pVirt = 0.0, _pLoud = 0.0;
   bool _pMono = false;
   bool _pSkipSilence = false;
+  int _pSkipSilencePadding = 20;
+  int _pSkipSilenceThreshold = -30;
 
   @override
   void initState() {
@@ -97,6 +99,8 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
       _pLoud = 0.0;
       _pMono = false;
       _pSkipSilence = false;
+      _pSkipSilencePadding = 20;
+      _pSkipSilenceThreshold = -30;
       _loadPreview();
     } else if (!shouldPreview && _previewMode) {
       _previewMode = false;
@@ -116,6 +120,8 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
       _pLoud = snap['loudnessGain'] as double;
       _pMono = snap['mono'] as bool;
       _pSkipSilence = snap['skipSilence'] as bool? ?? false;
+      _pSkipSilencePadding = snap['skipSilencePadding'] as int? ?? 20;
+      _pSkipSilenceThreshold = snap['skipSilenceThreshold'] as int? ?? -30;
       _pBands = List<double>.from((snap['bands'] as List).cast<double>());
     });
   }
@@ -131,6 +137,8 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
       'loudnessGain': _pLoud,
       'mono': _pMono,
       'skipSilence': _pSkipSilence,
+      'skipSilencePadding': _pSkipSilencePadding,
+      'skipSilenceThreshold': _pSkipSilenceThreshold,
       'bands': _pBands,
     });
   }
@@ -144,6 +152,8 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
   double get _vLoud => _previewMode ? _pLoud : _eq.loudnessGain;
   bool get _vMono => _previewMode ? _pMono : _eq.mono;
   bool get _vSkipSilence => _previewMode ? _pSkipSilence : _eq.skipSilence;
+  int get _vSkipSilencePadding => _previewMode ? _pSkipSilencePadding : _eq.skipSilencePadding;
+  int get _vSkipSilenceThreshold => _previewMode ? _pSkipSilenceThreshold : _eq.skipSilenceThreshold;
 
   void _setEnabled(bool v) {
     if (_previewMode) {
@@ -229,6 +239,24 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
     }
   }
 
+  void _setSkipSilencePadding(int v) {
+    if (_previewMode) {
+      setState(() => _pSkipSilencePadding = v);
+      _savePreview();
+    } else {
+      _eq.setSkipSilencePadding(v);
+    }
+  }
+
+  void _setSkipSilenceThreshold(int v) {
+    if (_previewMode) {
+      setState(() => _pSkipSilenceThreshold = v);
+      _savePreview();
+    } else {
+      _eq.setSkipSilenceThreshold(v);
+    }
+  }
+
   void _resetAll() {
     if (_previewMode) {
       setState(() {
@@ -239,6 +267,8 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
         _pLoud = 0.0;
         _pMono = false;
         _pSkipSilence = false;
+        _pSkipSilencePadding = 20;
+        _pSkipSilenceThreshold = -30;
       });
       _savePreview();
     } else {
@@ -564,6 +594,36 @@ class _EqualizerSheetContentState extends State<_EqualizerSheetContent> {
                       ],
                     ),
                   ),
+                  if (_vSkipSilence) ...[
+                    const SizedBox(height: 6),
+                    _EffectRow(
+                      icon: Icons.timer_outlined,
+                      label: 'Buffer',
+                      value: _vSkipSilencePadding.toDouble(),
+                      min: 0.0,
+                      max: 200.0,
+                      divisions: 40,
+                      defaultValue: 20.0,
+                      valueLabel: '$_vSkipSilencePadding ms',
+                      accent: accent,
+                      enabled: true,
+                      onChanged: (v) => _setSkipSilencePadding(v.round()),
+                    ),
+                    const SizedBox(height: 6),
+                    _EffectRow(
+                      icon: Icons.graphic_eq_rounded,
+                      label: 'Threshold',
+                      value: _vSkipSilenceThreshold.toDouble(),
+                      min: -50.0,
+                      max: -20.0,
+                      divisions: 30,
+                      defaultValue: -30.0,
+                      valueLabel: '$_vSkipSilenceThreshold dB',
+                      accent: accent,
+                      enabled: true,
+                      onChanged: (v) => _setSkipSilenceThreshold(v.round()),
+                    ),
+                  ],
                 ],
 
                 const SizedBox(height: 20),
@@ -660,6 +720,11 @@ class _EffectRow extends StatelessWidget {
   final IconData icon;
   final String label;
   final double value;
+  final double min;
+  final double max;
+  final int? divisions;
+  final String? valueLabel;
+  final double? defaultValue;
   final Color accent;
   final bool enabled;
   final ValueChanged<double> onChanged;
@@ -668,6 +733,11 @@ class _EffectRow extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.value,
+    this.min = 0.0,
+    this.max = 1.0,
+    this.divisions,
+    this.valueLabel,
+    this.defaultValue,
     required this.accent,
     required this.enabled,
     required this.onChanged,
@@ -676,6 +746,7 @@ class _EffectRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final display = valueLabel ?? '${(value * 100).round()}%';
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
@@ -696,6 +767,12 @@ class _EffectRow extends StatelessWidget {
             child: SliderTheme(
               data: SliderThemeData(
                 trackHeight: 3,
+                trackShape: defaultValue != null && max > min
+                    ? _DefaultMarkerTrackShape(
+                        fraction: (defaultValue! - min) / (max - min),
+                        markerColor: cs.onSurface.withValues(alpha: enabled ? 0.35 : 0.15),
+                      )
+                    : const RoundedRectSliderTrackShape(),
                 thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
                 overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
                 activeTrackColor: enabled ? accent : cs.onSurface.withValues(alpha: 0.24),
@@ -704,16 +781,17 @@ class _EffectRow extends StatelessWidget {
                 overlayColor: accent.withValues(alpha: 0.15),
               ),
               child: Slider(
-                value: value,
-                min: 0.0,
-                max: 1.0,
+                value: value.clamp(min, max),
+                min: min,
+                max: max,
+                divisions: divisions,
                 onChanged: enabled ? onChanged : null,
               ),
             ),
           ),
           SizedBox(
-            width: 32,
-            child: Text('${(value * 100).round()}%',
+            width: 48,
+            child: Text(display,
               textAlign: TextAlign.right,
               style: TextStyle(
                 color: enabled ? cs.onSurfaceVariant : cs.onSurface.withValues(alpha: 0.15),
@@ -721,6 +799,66 @@ class _EffectRow extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Slider track that draws a subtle vertical tick line at the default value.
+class _DefaultMarkerTrackShape extends RoundedRectSliderTrackShape {
+  final double fraction;
+  final Color markerColor;
+
+  const _DefaultMarkerTrackShape({
+    required this.fraction,
+    required this.markerColor,
+  });
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset offset, {
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    required Animation<double> enableAnimation,
+    required TextDirection textDirection,
+    required Offset thumbCenter,
+    Offset? secondaryOffset,
+    bool isDiscrete = false,
+    bool isEnabled = false,
+    double additionalActiveTrackHeight = 2,
+  }) {
+    super.paint(
+      context,
+      offset,
+      parentBox: parentBox,
+      sliderTheme: sliderTheme,
+      enableAnimation: enableAnimation,
+      textDirection: textDirection,
+      thumbCenter: thumbCenter,
+      secondaryOffset: secondaryOffset,
+      isDiscrete: isDiscrete,
+      isEnabled: isEnabled,
+      additionalActiveTrackHeight: additionalActiveTrackHeight,
+    );
+
+    final Rect trackRect = getPreferredRect(
+      parentBox: parentBox,
+      offset: offset,
+      sliderTheme: sliderTheme,
+      isEnabled: isEnabled,
+      isDiscrete: isDiscrete,
+    );
+
+    final double markerX = trackRect.left + trackRect.width * fraction.clamp(0.0, 1.0);
+    final Paint paint = Paint()
+      ..color = markerColor
+      ..strokeWidth = 2.0
+      ..strokeCap = StrokeCap.round;
+
+    context.canvas.drawLine(
+      Offset(markerX, trackRect.center.dy - 5),
+      Offset(markerX, trackRect.center.dy + 5),
+      paint,
     );
   }
 }

--- a/packages/just_audio/android/src/main/java/com/ryanheise/just_audio/AbsorbSilenceAudioProcessor.java
+++ b/packages/just_audio/android/src/main/java/com/ryanheise/just_audio/AbsorbSilenceAudioProcessor.java
@@ -1,0 +1,81 @@
+package com.ryanheise.just_audio;
+
+import androidx.media3.common.audio.AudioProcessor;
+import androidx.media3.common.audio.BaseAudioProcessor;
+import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor;
+import androidx.media3.common.util.UnstableApi;
+import java.nio.ByteBuffer;
+
+/**
+ * Dynamically configurable silence-skipping processor wrapping Media3's
+ * SilenceSkippingAudioProcessor.
+ */
+@UnstableApi
+public class AbsorbSilenceAudioProcessor extends BaseAudioProcessor {
+
+    public static final int DEFAULT_PADDING_MS = 20;
+    public static final int DEFAULT_THRESHOLD_DB = -30;
+
+    private boolean enabled = false;
+    private int paddingMs = DEFAULT_PADDING_MS;
+    private int thresholdDb = DEFAULT_THRESHOLD_DB;
+    private SilenceSkippingAudioProcessor delegate;
+
+    public synchronized void setParameters(boolean enabled, int paddingMs, int thresholdDb) {
+        this.enabled = enabled;
+        this.paddingMs = Math.max(0, paddingMs);
+        this.thresholdDb = thresholdDb;
+        updateDelegate();
+    }
+
+    private void updateDelegate() {
+        short thresholdLevel = (short) Math.max(1, (int) Math.round(Math.pow(10.0, thresholdDb / 20.0) * 32767.0));
+        long paddingUs = (long) paddingMs * 1000L;
+        delegate = new SilenceSkippingAudioProcessor(150_000L, paddingUs, thresholdLevel);
+        delegate.setEnabled(enabled);
+        if (inputAudioFormat != null && inputAudioFormat != AudioFormat.NOT_SET) {
+            try {
+                delegate.configure(inputAudioFormat);
+                delegate.flush();
+            } catch (Exception ignored) {}
+        }
+    }
+
+    @Override
+    protected AudioFormat onConfigure(AudioFormat inputAudioFormat) throws UnhandledAudioFormatException {
+        if (delegate == null) updateDelegate();
+        return delegate.configure(inputAudioFormat);
+    }
+
+    @Override
+    public boolean isActive() {
+        return enabled && delegate != null && delegate.isActive();
+    }
+
+    @Override
+    public void queueInput(ByteBuffer inputBuffer) {
+        if (delegate != null) {
+            delegate.queueInput(inputBuffer);
+        }
+    }
+
+    @Override
+    public ByteBuffer getOutput() {
+        return delegate != null ? delegate.getOutput() : EMPTY_BUFFER;
+    }
+
+    @Override
+    public boolean isEnded() {
+        return delegate != null ? delegate.isEnded() : super.isEnded();
+    }
+
+    @Override
+    protected void onFlush() {
+        if (delegate != null) delegate.flush();
+    }
+
+    @Override
+    protected void onReset() {
+        if (delegate != null) delegate.reset();
+    }
+}

--- a/packages/just_audio/android/src/main/java/com/ryanheise/just_audio/AbsorbSilenceController.java
+++ b/packages/just_audio/android/src/main/java/com/ryanheise/just_audio/AbsorbSilenceController.java
@@ -1,0 +1,22 @@
+package com.ryanheise.just_audio;
+
+/**
+ * Static bridge so external code (e.g. MainActivity) can update silence skipping
+ * parameters without directly importing AudioPlayer.
+ */
+public class AbsorbSilenceController {
+    public interface Callback {
+        void setSilenceParameters(boolean enabled, int paddingMs, int thresholdDb);
+    }
+
+    private static volatile Callback sCallback;
+
+    public static void register(Callback callback) {
+        sCallback = callback;
+    }
+
+    public static void setParameters(boolean enabled, int paddingMs, int thresholdDb) {
+        Callback cb = sCallback;
+        if (cb != null) cb.setSilenceParameters(enabled, paddingMs, thresholdDb);
+    }
+}

--- a/packages/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/packages/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -162,6 +162,8 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
     private ExoPlayer player;
     private androidx.media3.common.audio.ChannelMixingAudioProcessor monoProcessor;
     private static androidx.media3.common.audio.ChannelMixingAudioProcessor sMonoProcessor;
+    private AbsorbSilenceAudioProcessor silenceProcessor;
+    private static AbsorbSilenceAudioProcessor sSilenceProcessor;
     private Integer audioSessionId;
     private MediaSource mediaSource;
     private Integer currentIndex;
@@ -515,7 +517,16 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
                 result.success(new HashMap<String, Object>());
                 break;
             case "setSkipSilence":
-                setSkipSilenceEnabled((Boolean) call.argument("enabled"));
+                Boolean skipEnabled = (Boolean) call.argument("enabled");
+                Integer paddingMs = call.argument("paddingMs");
+                Integer thresholdDb = call.argument("thresholdDb");
+                if (silenceProcessor != null) {
+                    silenceProcessor.setParameters(
+                        skipEnabled != null && skipEnabled,
+                        paddingMs != null ? paddingMs : AbsorbSilenceAudioProcessor.DEFAULT_PADDING_MS,
+                        thresholdDb != null ? thresholdDb : AbsorbSilenceAudioProcessor.DEFAULT_THRESHOLD_DB
+                    );
+                }
                 result.success(new HashMap<String, Object>());
                 break;
             case "setMono":
@@ -950,17 +961,20 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
                 }));
             sMonoProcessor = monoProcessor;
             MonoController.register(AudioPlayer::setMonoEnabled);
+            silenceProcessor = new AbsorbSilenceAudioProcessor();
+            sSilenceProcessor = silenceProcessor;
+            AbsorbSilenceController.register(AudioPlayer::setSilenceParameters);
             RenderersFactory renderersFactory = new DefaultRenderersFactory(context) {
                 @Override
                 protected AudioSink buildAudioSink(
                         Context context,
                         boolean enableFloatOutput,
                         boolean enableAudioTrackPlaybackParams) {
-                    Log.i(TAG, "PATCH ACTIVE: buildAudioSink with SonicAudioProcessor + MonoProcessor, AudioTrack speed DISABLED");
+                    Log.i(TAG, "PATCH ACTIVE: buildAudioSink with SonicAudioProcessor + MonoProcessor + AbsorbSilenceAudioProcessor, AudioTrack speed DISABLED");
                     return new DefaultAudioSink.Builder(context)
                         .setEnableFloatOutput(enableFloatOutput)
                         .setEnableAudioTrackPlaybackParams(false)
-                        .setAudioProcessors(new androidx.media3.common.audio.AudioProcessor[]{sonicAudioProcessor, monoProcessor})
+                        .setAudioProcessors(new androidx.media3.common.audio.AudioProcessor[]{sonicAudioProcessor, monoProcessor, silenceProcessor})
                         .build();
                 }
             };
@@ -1190,7 +1204,13 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
     }
 
     public void setSkipSilenceEnabled(final boolean enabled) {
-        player.setSkipSilenceEnabled(enabled);
+        setSilenceParameters(enabled, AbsorbSilenceAudioProcessor.DEFAULT_PADDING_MS, AbsorbSilenceAudioProcessor.DEFAULT_THRESHOLD_DB);
+    }
+
+    public static void setSilenceParameters(final boolean enabled, final int paddingMs, final int thresholdDb) {
+        if (sSilenceProcessor != null) {
+            sSilenceProcessor.setParameters(enabled, paddingMs, thresholdDb);
+        }
     }
 
     private static void setMonoEnabled(final boolean enabled) {


### PR DESCRIPTION
Closes #364

### Summary
Adds configurable **Buffer (padding)** and **Threshold (dB cutoff)** sliders when **Skip Silence** is enabled on Android.

### Why
The default ExoPlayer 20 ms silence padding was cutting off word-initial unvoiced consonants (*s*, *th*, *f*, *p*) and trailing syllables on some audiobooks. Allowing users to adjust the buffer (0–200 ms, default 20 ms) and threshold (-50 to -20 dB, default -30 dB) resolves word clipping while keeping silence skipping fast and natural.

### Key Changes
- **Native Android pipeline**: Slim wrapper (`AbsorbSilenceAudioProcessor`) delegating directly to Media3's `SilenceSkippingAudioProcessor` with on-the-fly parameter updates.
- **Audio pipeline bridge**: Static `AbsorbSilenceController` mirroring the established `MonoController` pattern.
- **UI Sliders**: Reuses `_EffectRow` in the Equalizer sheet with default position indicator tick marks:
  - **Buffer**: `0 ms – 200 ms` (default: `20 ms`)
  - **Threshold**: `-50 dB – -20 dB` (default: `-30 dB`)
- **Persistence & Backup**: Integrated into scoped preferences and backup/restore.

### Testing
- Tested on Android with live run and release build.
- Verified slider adjustments immediately update audio playback in real-time.
- Verified per-book EQ overrides and reset button work as expected.

https://github.com/user-attachments/assets/3628a7d3-9d2a-4aec-9692-7a14f076559f

