### PR TITLE
Fix crash saving null now-playing values to the iOS widget

### DIFF
--- a/ios/Runner/AbsorbPlayerCore.swift
+++ b/ios/Runner/AbsorbPlayerCore.swift
@@ -228,7 +228,9 @@ final class AbsorbPlayerCore: NSObject, AbsorbPlayerCoreProtocol, @unchecked Sen
       emit("[NativeCore] ensureLoaded: no np_item_id in app group")
       return false
     }
-    let episodeId = defaults?.string(forKey: "np_episode_id")
+    // '' is the stored form of "no episode" (NSUserDefaults can't hold null).
+    let storedEpisodeId = defaults?.string(forKey: "np_episode_id")
+    let episodeId = (storedEpisodeId?.isEmpty ?? true) ? nil : storedEpisodeId
 
     // Engine already holds this exact book: adopt it, no reload.
     if AbsorbAudioEngine.shared.currentItemId == itemId, AbsorbAudioEngine.shared.isLoaded {

--- a/lib/services/home_widget_service.dart
+++ b/lib/services/home_widget_service.dart
@@ -231,7 +231,8 @@ class HomeWidgetService {
       final stashedEpisode = await HomeWidget.getWidgetData<String>(
         'np_episode_id',
       );
-      if (stashedEpisode != episodeId) return null;
+      // '' is the stored form of "no episode" (see updateNowPlaying).
+      if ((stashedEpisode ?? '') != (episodeId ?? '')) return null;
       final pos = await HomeWidget.getWidgetData<double>('np_position_s');
       return pos;
     } catch (e) {
@@ -774,9 +775,12 @@ class HomeWidgetService {
     final itemId = player.currentItemId;
     if (itemId == null) return;
     await HomeWidget.saveWidgetData<String>('np_item_id', itemId);
-    await HomeWidget.saveWidgetData<String?>(
+    // Dart null crosses the channel as NSNull, which NSUserDefaults rejects -
+    // binaries linked against the iOS 27 SDK turn that into an uncaught
+    // exception. Store '' for "no episode"; readers treat '' as absent.
+    await HomeWidget.saveWidgetData<String>(
       'np_episode_id',
-      player.currentEpisodeId,
+      player.currentEpisodeId ?? '',
     );
 
     final posSec = player.position.inMilliseconds / 1000.0;
@@ -1248,7 +1252,9 @@ class HomeWidgetService {
     );
 
     try {
-      await HomeWidget.saveWidgetData<String?>('widget_cover_path', coverPath);
+      // '' instead of null: NSNull isn't a valid NSUserDefaults value (see
+      // np_episode_id above). Readers on both platforms skip '' paths.
+      await HomeWidget.saveWidgetData<String>('widget_cover_path', coverPath ?? '');
       await _updateAllWidgets();
     } catch (e) {
       debugPrint('[WidgetDebug] cover save failed: $e');

--- a/lib/services/home_widget_service.dart
+++ b/lib/services/home_widget_service.dart
@@ -863,7 +863,8 @@ class HomeWidgetService {
     final coverPath = await HomeWidget.getWidgetData<String>(
       'widget_cover_path',
     );
-    if (coverPath != null) {
+    // '' is the stored form of "no cover" (see _updateCoverArt); don't mirror it.
+    if (coverPath != null && coverPath.isNotEmpty) {
       await HomeWidget.saveWidgetData<String>('np_cover_path', coverPath);
     }
     // GH #298: iOS native now-playing (AbsorbPlayerCore) reads these — feed it


### PR DESCRIPTION
## Summary
`HomeWidget.saveWidgetData` passed Dart `null` for `np_episode_id` (books have no episode) and `widget_cover_path`. Null crosses the platform channel as `NSNull`, which `NSUserDefaults` rejects; binaries linked against the iOS 27 SDK turn that rejection into an uncaught `NSInvalidArgumentException`, aborting the app the moment playback starts. Builds from older SDKs (current CI) only logged a warning, which is why the store build doesn't crash.

The fix stores `''` as the "absent" marker instead, matching the existing `widget_chapter` convention, and normalizes the readers: the Dart position-stash comparer and `AbsorbPlayerCore`'s episode-id load treat `''` as nil. Android widget readers already skip empty paths.

## Testing
- **iOS**: device tested — release build installed and verified on a physical iPhone (iOS 27); playback no longer crashes.
- **Android**: compile tested only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)