### PR TITLE
Fix complete series loading and current-book focus

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -157,6 +157,7 @@ dependencies {
 
     // SAF document moves for custom download folders (MainActivity.moveBookToSaf).
     implementation("androidx.documentfile:documentfile:1.0.1")
+    implementation("androidx.media:media:1.7.0")
 
     // Google Play Services — Chromecast + Wearable Data Layer (pushes ABS
     // session credentials to the paired Wear OS app so the watch can sign in

--- a/lib/providers/_lp_absorbing.dart
+++ b/lib/providers/_lp_absorbing.dart
@@ -886,7 +886,7 @@ mixin _AbsorbingMixin on ChangeNotifier, _StateMixin, _CoreMixin {
     }
     if (_api == null) return null;
     try {
-      final books = await _api!.getBooksBySeries(libraryId, seriesId, limit: 100);
+      final books = await _api!.getBooksBySeries(libraryId, seriesId, limit: 0);
       if (books.isNotEmpty) {
         _upNextSeriesCache[seriesId] = (DateTime.now(), books);
       }
@@ -1596,7 +1596,7 @@ mixin _AbsorbingMixin on ChangeNotifier, _StateMixin, _CoreMixin {
       books = await api.getBooksBySeries(
         libraryId,
         seriesId,
-        limit: 100,
+        limit: 0,
       );
     } catch (error) {
       debugPrint('[QueueDownload] Series fetch failed: $error');
@@ -1787,7 +1787,7 @@ mixin _AbsorbingMixin on ChangeNotifier, _StateMixin, _CoreMixin {
   Future<List<Map<String, dynamic>>> fetchBooksBySeries(
       String libraryId, String seriesId) async {
     if (_api == null) return const [];
-    final books = await _api!.getBooksBySeries(libraryId, seriesId, limit: 100);
+    final books = await _api!.getBooksBySeries(libraryId, seriesId, limit: 0);
     return books.whereType<Map<String, dynamic>>().toList();
   }
 

--- a/lib/providers/_lp_core.dart
+++ b/lib/providers/_lp_core.dart
@@ -3354,7 +3354,7 @@ mixin _CoreMixin on ChangeNotifier, _StateMixin {
     final books = await _api!.getBooksBySeries(
       libraryId ?? '',
       seriesId,
-      limit: 100,
+      limit: 0,
     );
     if (books.isEmpty) return;
 

--- a/lib/screens/absorbing_screen.dart
+++ b/lib/screens/absorbing_screen.dart
@@ -10,7 +10,8 @@ import '../services/download_service.dart';
 import '../services/queue_download_policy.dart';
 import '../services/scoped_prefs.dart';
 import '../widgets/absorb_page_header.dart';
-import '../main.dart' show flatNotifier, gradientIntensityNotifier, rootNavigatorKey;
+import '../main.dart'
+    show flatNotifier, gradientIntensityNotifier, rootNavigatorKey;
 import '../widgets/absorbing_card.dart';
 import '../widgets/offline_status_icon.dart';
 import '../widgets/overlay_toast.dart';
@@ -47,9 +48,11 @@ class AbsorbingScreen extends StatefulWidget {
   static void scrollToFirst() {
     final state = globalKey.currentState;
     if (state != null && state._pageController.hasClients) {
-      state._pageController.animateToPage(0,
-          duration: const Duration(milliseconds: 350),
-          curve: Curves.easeOutCubic);
+      state._pageController.animateToPage(
+        0,
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeOutCubic,
+      );
     }
   }
 
@@ -66,9 +69,11 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
   final _cardKeys = <String, GlobalKey<AbsorbingCardState>>{};
 
   GlobalKey<AbsorbingCardState> _cardKey(String absorbingKey) {
-    return _cardKeys.putIfAbsent(absorbingKey, () => GlobalKey<AbsorbingCardState>());
+    return _cardKeys.putIfAbsent(
+      absorbingKey,
+      () => GlobalKey<AbsorbingCardState>(),
+    );
   }
-
 
   final _cast = ChromecastService();
   String _queueMode = 'off';
@@ -109,9 +114,10 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
   String _activePlaylistChipLabel(LibraryProvider lib, AppLocalizations l) {
     final id = _queuePlaylistId;
     if (id == null) return l.queueModePlaylist;
-    final match = lib.playlists.cast<Map<String, dynamic>>().where(
-      (p) => p['id'] == id,
-    ).firstOrNull;
+    final match = lib.playlists
+        .cast<Map<String, dynamic>>()
+        .where((p) => p['id'] == id)
+        .firstOrNull;
     final n = match?['name'] as String?;
     if (n == null || n.isEmpty) return l.queueModePlaylist;
     return n.length > 24 ? '${n.substring(0, 23)}…' : n;
@@ -173,7 +179,8 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
     // walks the queue from the current item forward, so reordering items after
     // the front changes what's up next without changing the first key.
     final queueOrder = lib.absorbingBookIds.join(',');
-    final stamp = '$_queueMode|$_bookQueueMode|$_podcastQueueMode|$_mergeLibraries'
+    final stamp =
+        '$_queueMode|$_bookQueueMode|$_podcastQueueMode|$_mergeLibraries'
         '|$_queuePlaylistId|$_queueCollectionName|$currentId|$queueOrder';
     if (stamp == _upNextComputedFor) return;
     _upNextComputedFor = stamp;
@@ -221,7 +228,8 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
     _lastSeenHasBook = _player.hasBook;
     _lastSeenIsPlaying = _player.isPlaying;
     _lastSeenActiveSession = _player.hasActiveSession;
-    var shouldRebuild = hasBookChanged || isPlayingChanged || activeSessionChanged;
+    var shouldRebuild =
+        hasBookChanged || isPlayingChanged || activeSessionChanged;
 
     // Detect item or episode change (same show, different episode counts as a change)
     final itemChanged = _player.currentItemId != _lastPlayingId;
@@ -239,9 +247,12 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
         final playingKey = _player.currentEpisodeId != null
             ? '${_player.currentItemId!}-${_player.currentEpisodeId!}'
             : _player.currentItemId!;
-        lib.unblockFromAbsorbing(playingKey,
+        lib.unblockFromAbsorbing(
+          playingKey,
           episodeTitle: _player.currentEpisodeTitle,
-          episodeDuration: _player.currentEpisodeId != null ? _player.totalDuration : null,
+          episodeDuration: _player.currentEpisodeId != null
+              ? _player.totalDuration
+              : null,
         );
         // Persist so this item stays at front even if the app is killed
         _lastFinishedId = playingKey;
@@ -256,7 +267,9 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
           // No animation needed — persist the move-to-front immediately.
           lib.moveAbsorbingToFront(playingKey);
         }
-        WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToActiveCard());
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => _scrollToActiveCard(),
+        );
       } else if (wasPlayingId != null && !_isSyncing) {
         // Playback stopped — keep this item at the front of the list.
         // Don't call markFinishedLocally here: actual completion is handled
@@ -286,12 +299,15 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
       _lastFinishedId = castKey;
       ScopedPrefs.setString('absorbing_last_finished', castKey);
       final currentPage = _pageController.hasClients
-          ? (_pageController.page ?? 0).round() : 0;
+          ? (_pageController.page ?? 0).round()
+          : 0;
       _suppressReorder = currentPage > 0;
       if (!_suppressReorder) {
         lib.moveAbsorbingToFront(castKey);
       }
-      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToActiveCard());
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _scrollToActiveCard(),
+      );
     } else if (nowCasting) {
       _lastCastItemId = _cast.castingItemId;
       _lastCastEpisodeId = _cast.castingEpisodeId;
@@ -337,23 +353,29 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
         // After the animation lands at 0, release suppression so the list properly
         // reorders with the playing item at index 0.
         _pageController
-            .animateToPage(0,
-                duration: const Duration(milliseconds: 400),
-                curve: Curves.easeInOutCubic)
+            .animateToPage(
+              0,
+              duration: const Duration(milliseconds: 400),
+              curve: Curves.easeInOutCubic,
+            )
             .then((_) {
-          if (!mounted) return;
-          _suppressReorder = false;
-          // Persist the played item at front so subsequent plays
-          // maintain the correct order instead of reverting.
-          if (playingKey != null) {
-            context.read<LibraryProvider>().moveAbsorbingToFront(playingKey);
-          }
-          setState(() {});
-        });
+              if (!mounted) return;
+              _suppressReorder = false;
+              // Persist the played item at front so subsequent plays
+              // maintain the correct order instead of reverting.
+              if (playingKey != null) {
+                context.read<LibraryProvider>().moveAbsorbingToFront(
+                  playingKey,
+                );
+              }
+              setState(() {});
+            });
       } else {
-        _pageController.animateToPage(idx,
-            duration: const Duration(milliseconds: 350),
-            curve: Curves.easeOutCubic);
+        _pageController.animateToPage(
+          idx,
+          duration: const Duration(milliseconds: 350),
+          curve: Curves.easeOutCubic,
+        );
       }
     } else if (retries > 0) {
       // Book might not be in the list yet — retry after a rebuild
@@ -394,7 +416,6 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
     await lib.refresh();
   }
 
-
   /// Derive the absorbing key for an item map: compound "itemId-episodeId" for
   /// podcast episodes, plain "itemId" for books.
   String _absorbingKey(Map<String, dynamic> item) {
@@ -414,7 +435,11 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
 
     // Quick lookup of fresh data — only from the in-progress sections.
     // For podcast episodes, key by compound "itemId-episodeId".
-    const allowedSections = {'continue-listening', 'continue-series', 'downloaded-books'};
+    const allowedSections = {
+      'continue-listening',
+      'continue-series',
+      'downloaded-books',
+    };
     final sectionLookup = <String, Map<String, dynamic>>{};
     for (final section in lib.personalizedSections) {
       final sectionId = section['id'] as String? ?? '';
@@ -438,7 +463,10 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
     final items = <Map<String, dynamic>>[];
     final skippedKeys = <String, String>{};
     for (final key in lib.absorbingBookIds) {
-      if (removes.contains(key)) { skippedKeys[key] = 'removed'; continue; }
+      if (removes.contains(key)) {
+        skippedKeys[key] = 'removed';
+        continue;
+      }
       // Prefer fresh data from current library's sections
       final fromSection = sectionLookup[key];
       if (fromSection != null) {
@@ -451,11 +479,15 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
         final itemLibId = cached['libraryId'] as String?;
         final mediaType = cached['mediaType'] as String?;
         final isPodItem = mediaType == 'podcast' || key.length > 36;
-        if (_mergeLibraries || selectedLibraryId == null ||
-            (itemLibId != null ? itemLibId == selectedLibraryId : isPodItem == lib.isPodcastLibrary)) {
+        if (_mergeLibraries ||
+            selectedLibraryId == null ||
+            (itemLibId != null
+                ? itemLibId == selectedLibraryId
+                : isPodItem == lib.isPodcastLibrary)) {
           items.add(cached);
         } else {
-          skippedKeys[key] = 'wrong library (item=$itemLibId, selected=$selectedLibraryId)';
+          skippedKeys[key] =
+              'wrong library (item=$itemLibId, selected=$selectedLibraryId)';
         }
       } else {
         skippedKeys[key] = 'not in section or cache';
@@ -518,13 +550,19 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
       final activeIsPodcast = activeEpId != null;
       // Only show if the active item matches the current library type (or merge is on)
       if (_mergeLibraries || activeIsPodcast == isPod) {
-        final activeKey = activeEpId != null ? '$activeId-$activeEpId' : activeId;
+        final activeKey = activeEpId != null
+            ? '$activeId-$activeEpId'
+            : activeId;
 
-        final existingIdx = items.indexWhere((b) => _absorbingKey(b) == activeKey);
+        final existingIdx = items.indexWhere(
+          (b) => _absorbingKey(b) == activeKey,
+        );
         // Only pull the active item to the top while it's actually playing.
         // When paused, leave the queue order alone so a freshly-queued
         // "beginning" episode stays first instead of being bumped to 2nd.
-        final activePlaying = _player.hasBook ? _player.isPlaying : _cast.isCasting;
+        final activePlaying = _player.hasBook
+            ? _player.isPlaying
+            : _cast.isCasting;
         if (!_suppressReorder && existingIdx > 0 && activePlaying) {
           final item = items.removeAt(existingIdx);
           items.insert(0, item);
@@ -533,10 +571,7 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
           final entry = <String, dynamic>{
             'id': activeId,
             'media': {
-              'metadata': {
-                'title': activeTitle,
-                'authorName': activeAuthor,
-              },
+              'metadata': {'title': activeTitle, 'authorName': activeAuthor},
               'duration': activeDuration,
               'chapters': activeChapters,
             },
@@ -556,14 +591,20 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
 
     // When nothing is playing, keep the last-finished item at the front
     // Only if it matches the current library type
-    if (!_player.hasBook && !_cast.isCasting && _lastFinishedId != null && !removes.contains(_lastFinishedId)) {
+    if (!_player.hasBook &&
+        !_cast.isCasting &&
+        _lastFinishedId != null &&
+        !removes.contains(_lastFinishedId)) {
       // Compound podcast keys are "uuid-uuid" (>36 chars); plain book UUIDs are 36.
       final finishedIsPodcast = _lastFinishedId!.length > 36;
       if (_mergeLibraries || finishedIsPodcast == isPod) {
-        final finishedIdx = items.indexWhere((b) => _absorbingKey(b) == _lastFinishedId);
+        final finishedIdx = items.indexWhere(
+          (b) => _absorbingKey(b) == _lastFinishedId,
+        );
         // Don't pull the last-finished item over a brand-new "beginning"
         // episode that's deliberately sitting at the top.
-        final freshOnTop = items.isNotEmpty &&
+        final freshOnTop =
+            items.isNotEmpty &&
             _absorbingKey(items[0]) == lib.freshQueuedFrontKey;
         if (finishedIdx > 0 && !freshOnTop) {
           final item = items.removeAt(finishedIdx);
@@ -588,25 +629,30 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
     final lib = context.watch<LibraryProvider>();
     final mq = MediaQuery.of(context);
     final isTablet = mq.size.shortestSide >= 600;
-    final isPhoneLandscape = !isTablet && mq.orientation == Orientation.landscape;
+    final isPhoneLandscape =
+        !isTablet && mq.orientation == Orientation.landscape;
 
     // Swap the PageController when orientation changes so we can go nearly
     // edge-to-edge on phone landscape while keeping the side peek in portrait.
     if (_lastOrientation != null && _lastOrientation != mq.orientation) {
       final currentPage = _pageController.hasClients
-          ? (_pageController.page ?? _pageController.initialPage.toDouble()).round()
+          ? (_pageController.page ?? _pageController.initialPage.toDouble())
+                .round()
           : 0;
       final oldController = _pageController;
       _pageController = PageController(
         initialPage: currentPage,
         viewportFraction: isPhoneLandscape ? 0.95 : 0.92,
       );
-      WidgetsBinding.instance.addPostFrameCallback((_) => oldController.dispose());
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => oldController.dispose(),
+      );
     }
     _lastOrientation = mq.orientation;
 
     // Reset carousel to first card when library changes
-    if (lib.selectedLibraryId != _lastSeenLibraryId && _lastSeenLibraryId != null) {
+    if (lib.selectedLibraryId != _lastSeenLibraryId &&
+        _lastSeenLibraryId != null) {
       if (_pageController.hasClients) {
         _pageController.jumpToPage(0);
       }
@@ -614,7 +660,7 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
     _lastSeenLibraryId = lib.selectedLibraryId;
     final dl = DownloadService();
     var books = _getAbsorbingBooks(lib);
-    
+
     // When offline, only show downloaded books — but always keep the
     // currently playing/casting item visible so controls remain accessible.
     final effectiveOffline = lib.isOffline;
@@ -636,7 +682,8 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
       }).toList();
     }
 
-    final showBlockingLoader = lib.isLoading &&
+    final showBlockingLoader =
+        lib.isLoading &&
         books.isEmpty &&
         !_player.hasBook &&
         !_cast.isCasting &&
@@ -649,307 +696,440 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
     return Scaffold(
       backgroundColor: scaffoldBg,
       body: Container(
-        decoration: flatNotifier.value ? null : BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            stops: const [0.0, 0.22, 0.72, 1.0],
-            colors: [
-              cs.primary.withValues(alpha: gradientIntensityNotifier.value),
-              cs.surface,
-              lowerFade,
-              scaffoldBg,
-            ],
-          ),
-        ),
+        decoration: flatNotifier.value
+            ? null
+            : BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  stops: const [0.0, 0.22, 0.72, 1.0],
+                  colors: [
+                    cs.primary.withValues(
+                      alpha: gradientIntensityNotifier.value,
+                    ),
+                    cs.surface,
+                    lowerFade,
+                    scaffoldBg,
+                  ],
+                ),
+              ),
         child: SafeArea(
-        child: Builder(builder: (context) {
-          final offlineIcon = OfflineStatusIcon(
-            onTapWhenOnline: () {
-              lib.setManualOffline(true);
-              final dl = DownloadService();
-              final itemId = _player.currentItemId;
-              final epId = _player.currentEpisodeId;
-              final dlKey = epId != null && itemId != null
-                  ? '$itemId-$epId'
-                  : itemId;
-              if (dlKey == null || !dl.isDownloaded(dlKey)) {
-                _stopAndRefresh(lib);
-              }
-            },
-          );
+          child: Builder(
+            builder: (context) {
+              final offlineIcon = OfflineStatusIcon(
+                onTapWhenOnline: () {
+                  lib.setManualOffline(true);
+                  final dl = DownloadService();
+                  final itemId = _player.currentItemId;
+                  final epId = _player.currentEpisodeId;
+                  final dlKey = epId != null && itemId != null
+                      ? '$itemId-$epId'
+                      : itemId;
+                  if (dlKey == null || !dl.isDownloaded(dlKey)) {
+                    _stopAndRefresh(lib);
+                  }
+                },
+              );
 
-          final headerActions = <Widget>[
-            if (_player.hasBook)
-              GestureDetector(
-                onTap: _isSyncing ? null : () => _stopAndRefresh(lib),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-                  decoration: BoxDecoration(
-                    color: subtleBg,
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(color: subtleBorder),
-                  ),
-                  child: SizedBox(
-                    height: 20,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (_isSyncing)
-                          SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 1.5, color: muted))
-                        else
-                          Icon(Icons.stop_rounded, size: 18, color: muted),
-                        const SizedBox(width: 4),
-                        Text(l.absorbingStop, style: TextStyle(color: muted, fontSize: 13, fontWeight: FontWeight.w500)),
-                      ],
+              final headerActions = <Widget>[
+                if (_player.hasBook)
+                  GestureDetector(
+                    onTap: _isSyncing ? null : () => _stopAndRefresh(lib),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 5,
+                      ),
+                      decoration: BoxDecoration(
+                        color: subtleBg,
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(color: subtleBorder),
+                      ),
+                      child: SizedBox(
+                        height: 20,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (_isSyncing)
+                              SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 1.5,
+                                  color: muted,
+                                ),
+                              )
+                            else
+                              Icon(Icons.stop_rounded, size: 18, color: muted),
+                            const SizedBox(width: 4),
+                            Text(
+                              l.absorbingStop,
+                              style: TextStyle(
+                                color: muted,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  )
+                else if (!effectiveOffline)
+                  GestureDetector(
+                    onTap: _isSyncing
+                        ? null
+                        : () async {
+                            setState(() => _isSyncing = true);
+                            await _pullRefresh();
+                            if (mounted) setState(() => _isSyncing = false);
+                          },
+                    child: Container(
+                      padding: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        color: subtleBg,
+                        shape: BoxShape.circle,
+                        border: Border.all(color: subtleBorder),
+                      ),
+                      child: _isSyncing
+                          ? SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 1.5,
+                                color: muted,
+                              ),
+                            )
+                          : Icon(Icons.refresh_rounded, size: 18, color: muted),
                     ),
                   ),
-                ),
-              )
-            else if (!effectiveOffline)
-              GestureDetector(
-                onTap: _isSyncing ? null : () async {
-                  setState(() => _isSyncing = true);
-                  await _pullRefresh();
-                  if (mounted) setState(() => _isSyncing = false);
-                },
-                child: Container(
-                  padding: const EdgeInsets.all(6),
-                  decoration: BoxDecoration(
-                    color: subtleBg,
-                    shape: BoxShape.circle,
-                    border: Border.all(color: subtleBorder),
-                  ),
-                  child: _isSyncing
-                      ? SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 1.5, color: muted))
-                      : Icon(Icons.refresh_rounded, size: 18, color: muted),
-                ),
-              ),
-            if (books.isNotEmpty) ...[
-              const SizedBox(width: 8),
-              GestureDetector(
-                onTap: () => _showReorderSheet(context, lib, books),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-                  decoration: BoxDecoration(
-                    color: subtleBg,
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(color: subtleBorder),
-                  ),
-                  child: SizedBox(
-                    height: 20,
-                    child: Row(mainAxisSize: MainAxisSize.min, children: [
-                      Icon(Icons.reorder_rounded, size: 18, color: muted),
-                      if (_queueMode != 'off') ...[
-                        const SizedBox(width: 4),
-                        Text(
-                          _queueMode == 'playlist'
-                              ? _activePlaylistChipLabel(lib, l)
-                              : _queueMode == 'collection'
-                                  ? _activeCollectionChipLabel(l)
-                                  : _queueMode == 'auto_next'
-                                      ? (_mergeLibraries ? l.queueModeAuto : lib.isPodcastLibrary ? l.queueModeShowLabel : l.queueModeSeriesLabel)
-                                      : l.queueModeManual,
-                          style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: cs.primary),
-                        ),
-                      ],
-                    ]),
-                  ),
-                ),
-              ),
-            ],
-          ];
-
-          final pageDots = books.length > 1
-              ? _PageDots(count: books.length, controller: _pageController)
-              : null;
-
-          // Compact phone header: one row containing the ABSORB branding,
-          // offline icon, page dots, and actions. Skips the large "Absorbing"
-          // title row to give the card more vertical breathing room.
-          final compactHeader = Padding(
-            padding: const EdgeInsets.fromLTRB(20, 6, 20, 2),
-            child: Row(
-              children: [
-                Text(
-                  l.appTitle,
-                  style: tt.labelSmall?.copyWith(
-                    color: cs.onSurfaceVariant,
-                    letterSpacing: 4,
-                    fontWeight: FontWeight.w300,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                offlineIcon,
-                if (pageDots != null) ...[
-                  const SizedBox(width: 12),
-                  Expanded(child: pageDots),
-                  const SizedBox(width: 12),
-                ] else
-                  const Spacer(),
-                ...headerActions,
-              ],
-            ),
-          );
-
-          final fullHeader = AbsorbPageHeader(
-            title: Wording.of(context).absorbingTitle,
-            padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
-            trailing: offlineIcon,
-            actions: headerActions,
-          );
-
-        return Column(
-          children: [
-            // ── Header ──
-            // Phone landscape uses the compact single-row header; everything
-            // else (portrait, tablets in any orientation) keeps the full header.
-            if (isPhoneLandscape) compactHeader else fullHeader,
-            // Hide Up Next when the session is stopped (not merely paused) -
-            // hasActiveSession stays true while paused but goes false once the
-            // engine is stopped, so a stopped session with items still in the
-            // queue won't show a confusing "Nothing is up next".
-            if (_player.hasActiveSession && _showUpNextLabel && _queueMode != 'off' && books.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(20, 0, 20, 2),
-                child: Align(
-                  alignment: Alignment.centerRight,
-                  child: Builder(builder: (context) {
-                    final isDark = Theme.of(context).brightness == Brightness.dark;
-                    final greenColor = isDark ? Colors.greenAccent[400] : Colors.green.shade700;
-                    final redColor = isDark ? Colors.redAccent[200] : Colors.red.shade700;
-                    final hasNext = _upNextLabel != null;
-                    return Text(
-                      hasNext ? l.upNext(_upNextLabel!) : l.nothingUpNext,
-                      style: TextStyle(
-                        fontSize: 10,
-                        fontWeight: FontWeight.w600,
-                        color: hasNext ? greenColor : redColor,
+                if (books.isNotEmpty) ...[
+                  const SizedBox(width: 8),
+                  GestureDetector(
+                    onTap: () => _showReorderSheet(context, lib, books),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 5,
                       ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    );
-                  }),
+                      decoration: BoxDecoration(
+                        color: subtleBg,
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(color: subtleBorder),
+                      ),
+                      child: SizedBox(
+                        height: 20,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.reorder_rounded, size: 18, color: muted),
+                            if (_queueMode != 'off') ...[
+                              const SizedBox(width: 4),
+                              Text(
+                                _queueMode == 'playlist'
+                                    ? _activePlaylistChipLabel(lib, l)
+                                    : _queueMode == 'collection'
+                                    ? _activeCollectionChipLabel(l)
+                                    : _queueMode == 'auto_next'
+                                    ? (_mergeLibraries
+                                          ? l.queueModeAuto
+                                          : lib.isPodcastLibrary
+                                          ? l.queueModeShowLabel
+                                          : l.queueModeSeriesLabel)
+                                    : l.queueModeManual,
+                                style: TextStyle(
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w600,
+                                  color: cs.primary,
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ];
+
+              final pageDots = books.length > 1
+                  ? _PageDots(count: books.length, controller: _pageController)
+                  : null;
+
+              // Compact phone header: one row containing the ABSORB branding,
+              // offline icon, page dots, and actions. Skips the large "Absorbing"
+              // title row to give the card more vertical breathing room.
+              final compactHeader = Padding(
+                padding: const EdgeInsets.fromLTRB(20, 6, 20, 2),
+                child: Row(
+                  children: [
+                    Text(
+                      l.appTitle,
+                      style: tt.labelSmall?.copyWith(
+                        color: cs.onSurfaceVariant,
+                        letterSpacing: 4,
+                        fontWeight: FontWeight.w300,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    offlineIcon,
+                    if (pageDots != null) ...[
+                      const SizedBox(width: 12),
+                      Expanded(child: pageDots),
+                      const SizedBox(width: 12),
+                    ] else
+                      const Spacer(),
+                    ...headerActions,
+                  ],
                 ),
-              ),
-            // ── Page Dots (the compact landscape header inlines them) ──
-            if (!isPhoneLandscape && pageDots != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 4, bottom: 2),
-                child: pageDots,
-              ),
-            // ── Cards (refreshable) ──
-            Expanded(
-              child: showBlockingLoader
-                  ? Center(child: CircularProgressIndicator(strokeWidth: 2, color: cs.onSurface.withValues(alpha: 0.24)))
-                  : books.isEmpty
-                      ? _emptyState(cs, tt, effectiveOffline, l)
-                      : books.length == 1
-                          ? LayoutBuilder(
-                              builder: (context, constraints) {
-                                final vPad = isPhoneLandscape
-                                    ? 0.0
-                                    : (constraints.maxHeight * 0.01).clamp(2.0, 16.0);
-                                final hPad = isPhoneLandscape ? 0.0 : 4.0;
-                                return Padding(
-                                  padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
-                                  child: RepaintBoundary(child: AbsorbingCard(key: _cardKey(_absorbingKey(books[0])), item: books[0], player: _player)),
-                                );
-                              },
-                            )
-                          : PageView.builder(
-                          controller: _pageController,
-                          scrollDirection: Axis.horizontal,
-                          clipBehavior: Clip.none,
-                          physics: const PageScrollPhysics(parent: ClampingScrollPhysics()),
-                          itemCount: books.length,
-                          itemBuilder: (_, i) => LayoutBuilder(
+              );
+
+              final fullHeader = AbsorbPageHeader(
+                title: Wording.of(context).absorbingTitle,
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+                trailing: offlineIcon,
+                actions: headerActions,
+              );
+
+              return Column(
+                children: [
+                  // ── Header ──
+                  // Phone landscape uses the compact single-row header; everything
+                  // else (portrait, tablets in any orientation) keeps the full header.
+                  if (isPhoneLandscape) compactHeader else fullHeader,
+                  // Hide Up Next when the session is stopped (not merely paused) -
+                  // hasActiveSession stays true while paused but goes false once the
+                  // engine is stopped, so a stopped session with items still in the
+                  // queue won't show a confusing "Nothing is up next".
+                  if (_player.hasActiveSession &&
+                      _showUpNextLabel &&
+                      _queueMode != 'off' &&
+                      books.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 0, 20, 2),
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: Builder(
+                          builder: (context) {
+                            final isDark =
+                                Theme.of(context).brightness == Brightness.dark;
+                            final greenColor = isDark
+                                ? Colors.greenAccent[400]
+                                : Colors.green.shade700;
+                            final redColor = isDark
+                                ? Colors.redAccent[200]
+                                : Colors.red.shade700;
+                            final hasNext = _upNextLabel != null;
+                            return Text(
+                              hasNext
+                                  ? l.upNext(_upNextLabel!)
+                                  : l.nothingUpNext,
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                color: hasNext ? greenColor : redColor,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  // ── Page Dots (the compact landscape header inlines them) ──
+                  if (!isPhoneLandscape && pageDots != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4, bottom: 2),
+                      child: pageDots,
+                    ),
+                  // ── Cards (refreshable) ──
+                  Expanded(
+                    child: showBlockingLoader
+                        ? Center(
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: cs.onSurface.withValues(alpha: 0.24),
+                            ),
+                          )
+                        : books.isEmpty
+                        ? _emptyState(cs, tt, effectiveOffline, l)
+                        : books.length == 1
+                        ? LayoutBuilder(
                             builder: (context, constraints) {
-                              final cardWidth = constraints.maxWidth;
                               final vPad = isPhoneLandscape
                                   ? 0.0
-                                  : (constraints.maxHeight * 0.01).clamp(2.0, 16.0);
+                                  : (constraints.maxHeight * 0.01).clamp(
+                                      2.0,
+                                      16.0,
+                                    );
                               final hPad = isPhoneLandscape ? 0.0 : 4.0;
-                              return AnimatedBuilder(
-                                animation: _pageController,
-                                builder: (context, child) {
-                                  double distFromCenter = 0.0;
-                                  double rawDist = 0.0;
-                                  if (_pageController.hasClients && _pageController.positions.length == 1 && _pageController.position.haveDimensions) {
-                                    final page = _pageController.page ?? _pageController.initialPage.toDouble();
-                                    rawDist = page - i; // negative = card is to the right
-                                    distFromCenter = rawDist.abs();
-                                  }
-                                  final double scaleX;
-                                  if (distFromCenter >= 1.0) {
-                                    scaleX = 0.85;
-                                  } else {
-                                    // Use easeOut curve for smoother transition
-                                    final t = Curves.easeOut.transform(1.0 - distFromCenter);
-                                    scaleX = 0.85 + (t * 0.15); // 0.85 → 1.0
-                                  }
-                                  // Calculate how much space the squeeze frees up, then translate toward center
-                                  final squeezedWidth = cardWidth * scaleX;
-                                  final freedSpace = cardWidth - squeezedWidth;
-                                  // Pull card toward center by half the freed space
-                                  final direction = rawDist > 0 ? 1.0 : (rawDist < 0 ? -1.0 : 0.0);
-                                  final translateX = direction * freedSpace * 0.45;
-
-                                  return Transform(
-                                    alignment: Alignment.center,
-                                    transform: Matrix4.identity()
-                                      ..translate(translateX, 0.0, 0.0)
-                                      ..scale(scaleX, 1.0, 1.0),
-                                    child: Padding(
-                                      padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
-                                      child: child,
-                                    ),
-                                  );
-                                },
-                                child: RepaintBoundary(child: AbsorbingCard(key: _cardKey(_absorbingKey(books[i])), item: books[i], player: _player)),
+                              return Padding(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: hPad,
+                                  vertical: vPad,
+                                ),
+                                child: RepaintBoundary(
+                                  child: AbsorbingCard(
+                                    key: _cardKey(_absorbingKey(books[0])),
+                                    item: books[0],
+                                    player: _player,
+                                  ),
+                                ),
                               );
                             },
+                          )
+                        : PageView.builder(
+                            controller: _pageController,
+                            scrollDirection: Axis.horizontal,
+                            clipBehavior: Clip.none,
+                            physics: const PageScrollPhysics(
+                              parent: ClampingScrollPhysics(),
+                            ),
+                            itemCount: books.length,
+                            itemBuilder: (_, i) => LayoutBuilder(
+                              builder: (context, constraints) {
+                                final cardWidth = constraints.maxWidth;
+                                final vPad = isPhoneLandscape
+                                    ? 0.0
+                                    : (constraints.maxHeight * 0.01).clamp(
+                                        2.0,
+                                        16.0,
+                                      );
+                                final hPad = isPhoneLandscape ? 0.0 : 4.0;
+                                return AnimatedBuilder(
+                                  animation: _pageController,
+                                  builder: (context, child) {
+                                    double distFromCenter = 0.0;
+                                    double rawDist = 0.0;
+                                    if (_pageController.hasClients &&
+                                        _pageController.positions.length == 1 &&
+                                        _pageController
+                                            .position
+                                            .haveDimensions) {
+                                      final page =
+                                          _pageController.page ??
+                                          _pageController.initialPage
+                                              .toDouble();
+                                      rawDist =
+                                          page -
+                                          i; // negative = card is to the right
+                                      distFromCenter = rawDist.abs();
+                                    }
+                                    final double scaleX;
+                                    if (distFromCenter >= 1.0) {
+                                      scaleX = 0.85;
+                                    } else {
+                                      // Use easeOut curve for smoother transition
+                                      final t = Curves.easeOut.transform(
+                                        1.0 - distFromCenter,
+                                      );
+                                      scaleX = 0.85 + (t * 0.15); // 0.85 → 1.0
+                                    }
+                                    // Calculate how much space the squeeze frees up, then translate toward center
+                                    final squeezedWidth = cardWidth * scaleX;
+                                    final freedSpace =
+                                        cardWidth - squeezedWidth;
+                                    // Pull card toward center by half the freed space
+                                    final direction = rawDist > 0
+                                        ? 1.0
+                                        : (rawDist < 0 ? -1.0 : 0.0);
+                                    final translateX =
+                                        direction * freedSpace * 0.45;
+
+                                    return Transform(
+                                      alignment: Alignment.center,
+                                      transform: Matrix4.identity()
+                                        ..translate(translateX, 0.0, 0.0)
+                                        ..scale(scaleX, 1.0, 1.0),
+                                      child: Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal: hPad,
+                                          vertical: vPad,
+                                        ),
+                                        child: child,
+                                      ),
+                                    );
+                                  },
+                                  child: RepaintBoundary(
+                                    child: AbsorbingCard(
+                                      key: _cardKey(_absorbingKey(books[i])),
+                                      item: books[i],
+                                      player: _player,
+                                    ),
+                                  ),
+                                );
+                              },
+                            ),
                           ),
-                        ),
-            ),
-          ],
-        );
-        }),
-      ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
       ),
     );
   }
 
-  Widget _emptyState(ColorScheme cs, TextTheme tt, bool isOffline, AppLocalizations l) {
+  Widget _emptyState(
+    ColorScheme cs,
+    TextTheme tt,
+    bool isOffline,
+    AppLocalizations l,
+  ) {
     final lib = context.read<LibraryProvider>();
     final isPod = lib.isPodcastLibrary;
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(isOffline ? Icons.cloud_off_rounded
-              : isPod ? Icons.podcasts_rounded : Icons.headphones_rounded,
-            size: 64, color: cs.onSurface.withValues(alpha: 0.15)),
+          Icon(
+            isOffline
+                ? Icons.cloud_off_rounded
+                : isPod
+                ? Icons.podcasts_rounded
+                : Icons.headphones_rounded,
+            size: 64,
+            color: cs.onSurface.withValues(alpha: 0.15),
+          ),
           const SizedBox(height: 16),
-          Text(isOffline
-              ? (isPod ? l.absorbingNoDownloadedEpisodes : l.absorbingNoDownloadedBooks)
-              : (isPod ? l.absorbingNothingPlayingYet : Wording.of(context).absorbingNothingAbsorbingYet),
-            style: tt.titleMedium?.copyWith(color: cs.onSurfaceVariant)),
+          Text(
+            isOffline
+                ? (isPod
+                      ? l.absorbingNoDownloadedEpisodes
+                      : l.absorbingNoDownloadedBooks)
+                : (isPod
+                      ? l.absorbingNothingPlayingYet
+                      : Wording.of(context).absorbingNothingAbsorbingYet),
+            style: tt.titleMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
           const SizedBox(height: 8),
-          Text(isOffline
-              ? (isPod ? l.absorbingDownloadEpisodesToListen : l.absorbingDownloadBooksToListen)
-              : (isPod ? l.absorbingStartEpisodeFromShows : l.absorbingStartBookFromLibrary),
-            style: tt.bodySmall?.copyWith(color: cs.onSurface.withValues(alpha: 0.24))),
+          Text(
+            isOffline
+                ? (isPod
+                      ? l.absorbingDownloadEpisodesToListen
+                      : l.absorbingDownloadBooksToListen)
+                : (isPod
+                      ? l.absorbingStartEpisodeFromShows
+                      : l.absorbingStartBookFromLibrary),
+            style: tt.bodySmall?.copyWith(
+              color: cs.onSurface.withValues(alpha: 0.24),
+            ),
+          ),
         ],
       ),
     );
   }
 
-  void _showReorderSheet(BuildContext context, LibraryProvider lib, List<Map<String, dynamic>> books) {
+  void _showReorderSheet(
+    BuildContext context,
+    LibraryProvider lib,
+    List<Map<String, dynamic>> books,
+  ) {
     final keys = books.map((b) => _absorbingKey(b)).toList();
     final media = MediaQuery.of(context);
-    final needsMoreRoom = media.size.height < 600 ||
-        media.textScaler.scale(1) > 1.2;
+    final needsMoreRoom =
+        media.size.height < 600 || media.textScaler.scale(1) > 1.2;
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -977,9 +1157,14 @@ class _AbsorbingScreenState extends State<AbsorbingScreen> {
               final pid = await PlayerSettings.getQueuePlaylistId();
               if (pid == null) {
                 if (context.mounted) {
-                  final hint = AppLocalizations.of(context)!.queueModePlaylistHint;
-                  showOverlayToast(context, hint,
-                      icon: Icons.playlist_play_rounded);
+                  final hint = AppLocalizations.of(
+                    context,
+                  )!.queueModePlaylistHint;
+                  showOverlayToast(
+                    context,
+                    hint,
+                    icon: Icons.playlist_play_rounded,
+                  );
                 }
                 return;
               }
@@ -1019,56 +1204,68 @@ class _PageDots extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return LayoutBuilder(builder: (context, constraints) {
-      // Active dot is 20 wide, inactive is 6, each has horizontal padding on both sides.
-      // Solve for padding: count * (6 + 2*pad) + (20 - 6) <= maxWidth
-      // pad = (maxWidth - 14 - count * 6) / (count * 2)
-      const double dotSize = 6;
-      const double activeDotWidth = 20;
-      final maxWidth = constraints.maxWidth;
-      final extraActive = activeDotWidth - dotSize;
-      final available = maxWidth - extraActive - count * dotSize;
-      final hPad = (available / (count * 2)).clamp(1.5, 8.0);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Active dot is 20 wide, inactive is 6, each has horizontal padding on both sides.
+        // Solve for padding: count * (6 + 2*pad) + (20 - 6) <= maxWidth
+        // pad = (maxWidth - 14 - count * 6) / (count * 2)
+        const double dotSize = 6;
+        const double activeDotWidth = 20;
+        final maxWidth = constraints.maxWidth;
+        final extraActive = activeDotWidth - dotSize;
+        final available = maxWidth - extraActive - count * dotSize;
+        final hPad = (available / (count * 2)).clamp(1.5, 8.0);
 
-      return ListenableBuilder(
-        listenable: controller,
-        builder: (_, __) {
-          final page = controller.hasClients && controller.positions.length == 1 ? (controller.page ?? 0).round() : 0;
-          // The compact phone header can leave less width than the dots'
-          // minimum footprint (padding bottoms out at 1.5); an unclipped Row
-          // then paints under the Stop button. Scale the whole strip down
-          // instead when it genuinely doesn't fit.
-          return FittedBox(
-            fit: BoxFit.scaleDown,
-            child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: List.generate(count, (i) {
-              final active = i == page;
-              return GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () => controller.animateToPage(i,
-                  duration: const Duration(milliseconds: 400),
-                  curve: Curves.easeOutCubic),
-                child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: hPad, vertical: 12),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeOutCubic,
-                    width: active ? activeDotWidth : dotSize,
-                    height: dotSize,
-                    decoration: BoxDecoration(
-                      color: active ? cs.onSurface.withValues(alpha: 0.54) : cs.onSurface.withValues(alpha: 0.15),
-                      borderRadius: BorderRadius.circular(3),
+        return ListenableBuilder(
+          listenable: controller,
+          builder: (_, __) {
+            final page =
+                controller.hasClients && controller.positions.length == 1
+                ? (controller.page ?? 0).round()
+                : 0;
+            // The compact phone header can leave less width than the dots'
+            // minimum footprint (padding bottoms out at 1.5); an unclipped Row
+            // then paints under the Stop button. Scale the whole strip down
+            // instead when it genuinely doesn't fit.
+            return FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: List.generate(count, (i) {
+                  final active = i == page;
+                  return GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () => controller.animateToPage(
+                      i,
+                      duration: const Duration(milliseconds: 400),
+                      curve: Curves.easeOutCubic,
                     ),
-                  ),
-                ),
-              );
-            }),
-            ),
-          );
-        },
-      );
-    });
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: hPad,
+                        vertical: 12,
+                      ),
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeOutCubic,
+                        width: active ? activeDotWidth : dotSize,
+                        height: dotSize,
+                        decoration: BoxDecoration(
+                          color: active
+                              ? cs.onSurface.withValues(alpha: 0.54)
+                              : cs.onSurface.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(3),
+                        ),
+                      ),
+                    ),
+                  );
+                }),
+              ),
+            );
+          },
+        );
+      },
+    );
   }
 }
 
@@ -1110,14 +1307,13 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
   late final DownloadService _downloads;
   late final AudioPlayerService _player;
   String? _currentItemId;
+  bool _didScrollToCurrentSeriesItem = false;
 
   @override
   void initState() {
     super.initState();
     _order = List.from(widget.keys);
-    _booksByKey = {
-      for (final b in widget.books) widget.absorbingKeyFn(b): b,
-    };
+    _booksByKey = {for (final b in widget.books) widget.absorbingKeyFn(b): b};
     _queueMode = widget.queueMode;
     _currentItemId = widget.currentItemId;
     _downloads = DownloadService()..addListener(_onDownloadsChanged);
@@ -1154,8 +1350,8 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     final nextKey = itemId == null
         ? null
         : episodeId == null
-            ? itemId
-            : '$itemId-$episodeId';
+        ? itemId
+        : '$itemId-$episodeId';
     if (!mounted || nextKey == _currentItemId) return;
     setState(() {
       _currentItemId = nextKey;
@@ -1166,6 +1362,7 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
       _showEpisodes = null;
       _showItem = null;
       _showName = null;
+      _didScrollToCurrentSeriesItem = false;
     });
     final showId = _currentPodcastShowId;
     if (showId != null) {
@@ -1210,7 +1407,8 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     final count = await PlayerSettings.getRollingDownloadCount();
     if (!mounted ||
         queueMode != _queueMode ||
-        sourceId != _activeAutoDownloadSourceId) return;
+        sourceId != _activeAutoDownloadSourceId)
+      return;
     setState(() {
       _queueAutoDownload = resolveQueueAutoDownloadEnabled(
         queueMode: queueMode,
@@ -1249,10 +1447,10 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
         final kind = _queueMode == 'playlist'
             ? 'playlist'
             : _queueMode == 'collection'
-                ? 'collection'
-                : _currentPodcastShowId != null
-                    ? 'podcast'
-                    : 'series';
+            ? 'collection'
+            : _currentPodcastShowId != null
+            ? 'podcast'
+            : 'series';
         await widget.lib.enableRollingDownload(sourceId, kind: kind);
       } else {
         await widget.lib.disableRollingDownload(sourceId);
@@ -1342,7 +1540,8 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     if (data == null) return;
     final (sid, _) = widget.lib.extractSeries(data);
     if (sid == null) return;
-    final libraryId = data['libraryId'] as String? ?? widget.lib.selectedLibraryId;
+    final libraryId =
+        data['libraryId'] as String? ?? widget.lib.selectedLibraryId;
     if (libraryId == null) return;
     final books = await auth.fetchBooksBySeries(libraryId, sid);
     if (!mounted ||
@@ -1351,6 +1550,15 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
         _currentItemId != currentId) {
       return;
     }
+    // Keep the order stable outside build so the current item's index can
+    // drive the initial scroll position.
+    books.sort((a, b) {
+      final (_, aSequence) = widget.lib.extractSeries(a);
+      final (_, bSequence) = widget.lib.extractSeries(b);
+      return (aSequence ?? double.maxFinite).compareTo(
+        bSequence ?? double.maxFinite,
+      );
+    });
     // Pull the series name from the current book's metadata.
     final media = data['media'] as Map<String, dynamic>? ?? const {};
     final metadata = media['metadata'] as Map<String, dynamic>? ?? const {};
@@ -1370,6 +1578,50 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
       _seriesBooks = books;
       _seriesId = sid;
       _seriesName = seriesName;
+    });
+    _scrollToCurrentSeriesItem(books, currentId);
+  }
+
+  void _scrollToCurrentSeriesItem(
+    List<Map<String, dynamic>> books,
+    String currentId, {
+    int retries = 2,
+  }) {
+    if (_didScrollToCurrentSeriesItem) return;
+    final index = books.indexWhere((book) => book['id'] == currentId);
+    if (index < 1) {
+      _didScrollToCurrentSeriesItem = index == 0;
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          _didScrollToCurrentSeriesItem ||
+          _queueMode != 'auto_next' ||
+          _currentItemId != currentId) {
+        return;
+      }
+      final controller = widget.scrollController;
+      if (!controller.hasClients) {
+        if (retries > 0) {
+          _scrollToCurrentSeriesItem(books, currentId, retries: retries - 1);
+        }
+        return;
+      }
+      // Derive the average row extent from the laid-out list rather than
+      // assuming a fixed height. The sheet's viewport is still settling when
+      // it opens, and text scale can change individual row heights.
+      final position = controller.position;
+      final bottomPadding = MediaQuery.of(context).viewPadding.bottom + 16;
+      final itemExtent =
+          (position.maxScrollExtent +
+              position.viewportDimension -
+              bottomPadding) /
+          books.length;
+      final offset =
+          (index * itemExtent - position.viewportDimension / 2 + itemExtent / 2)
+              .clamp(0.0, position.maxScrollExtent);
+      controller.jumpTo(offset);
+      _didScrollToCurrentSeriesItem = true;
     });
   }
 
@@ -1448,8 +1700,8 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     final sourceId = mode == 'playlist'
         ? await PlayerSettings.getQueuePlaylistId()
         : mode == 'collection'
-            ? await PlayerSettings.getQueueCollectionId()
-            : null;
+        ? await PlayerSettings.getQueueCollectionId()
+        : null;
     if (!mounted) return;
     final modeChanged = mode != _queueMode;
     final sourceChanged = sourceId != _activeQueueSourceId;
@@ -1485,215 +1737,321 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
         color: cs.surface,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
       ),
-      child: Column(children: [
-        // Handle
-        Center(child: Container(
-          margin: const EdgeInsets.only(top: 8),
-          width: 32, height: 4,
-          decoration: BoxDecoration(
-            color: cs.onSurface.withValues(alpha: 0.2),
-            borderRadius: BorderRadius.circular(2),
-          ),
-        )),
-        // Header
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 8, 4),
-          child: Row(children: [
-            Expanded(child: Text(l.absorbingManageQueue,
-              style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w600))),
-            TextButton(
-              onPressed: () {
-                widget.lib.reorderAbsorbing(_order);
-                Navigator.pop(context);
-              },
-              child: Text(l.absorbingDone),
-            ),
-          ]),
-        ),
-        // Queue mode toggle
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 6),
-          child: SegmentedButton<String>(
-            segments: [
-              ButtonSegment(value: 'off', icon: const Icon(Icons.stop_rounded, size: 16), label: FittedBox(fit: BoxFit.scaleDown, child: Text(l.queueModeOff, maxLines: 1))),
-              ButtonSegment(value: 'manual', icon: const Icon(Icons.queue_music_rounded, size: 16), label: FittedBox(fit: BoxFit.scaleDown, child: Text(l.queueModeManual, maxLines: 1))),
-              ButtonSegment(value: 'auto_next', icon: const Icon(Icons.skip_next_rounded, size: 16),
-                label: FittedBox(fit: BoxFit.scaleDown, child: Text(widget.isMerged ? l.queueModeAuto : _currentIsPodcast ? l.queueModeShowLabel : l.queueModeSeriesLabel, maxLines: 1))),
-              ButtonSegment(value: 'playlist', icon: const Icon(Icons.playlist_play_rounded, size: 16), label: FittedBox(fit: BoxFit.scaleDown, child: Text(l.queueModePlaylist, maxLines: 1))),
-              // Collection mode is entered via a collection's Play button, not
-              // picked here - shown only while active so the selection is valid.
-              if (_queueMode == 'collection')
-                ButtonSegment(value: 'collection', icon: const Icon(Icons.collections_bookmark_rounded, size: 16), label: FittedBox(fit: BoxFit.scaleDown, child: Text(l.queueModeCollection, maxLines: 1))),
-            ],
-            selected: {_queueMode},
-            onSelectionChanged: (v) {
-              if (v.isNotEmpty) widget.onQueueModeChanged(v.first);
-            },
-            style: ButtonStyle(
-              visualDensity: VisualDensity.compact,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      child: Column(
+        children: [
+          // Handle
+          Center(
+            child: Container(
+              margin: const EdgeInsets.only(top: 8),
+              width: 32,
+              height: 4,
+              decoration: BoxDecoration(
+                color: cs.onSurface.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(2),
+              ),
             ),
           ),
-        ),
-        if (_queueMode != 'off')
+          // Header
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-            child: Column(children: [
-              Row(children: [
-                Expanded(child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(_autoDownloadLabel(l),
-                        style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
-                    Text(
-                      _queueAutoDownload
-                          ? l.autoDownloadQueueOnSubtitle(_rollingDownloadCount)
-                          : l.autoDownloadQueueOffSubtitle,
-                      style: tt.bodySmall?.copyWith(
-                          color: cs.onSurfaceVariant, fontSize: 11.5),
-                    ),
-                  ],
-                )),
-                if (_queueAutoDownload)
-                  Tooltip(
-                    message: l.keepNext,
-                    child: DropdownButtonHideUnderline(
-                      child: DropdownButton<int>(
-                        value: _rollingDownloadCount,
-                        isDense: true,
-                        items: const [2, 3, 4, 5]
-                            .map((count) => DropdownMenuItem(
-                                  value: count,
-                                  child: Text('$count'),
-                                ))
-                            .toList(),
-                        onChanged: _queueDownloadSettingsLoaded
-                            ? (value) async {
-                                if (value == null) return;
-                                setState(() => _rollingDownloadCount = value);
-                                await PlayerSettings.setRollingDownloadCount(value);
-                                unawaited(widget.lib.syncQueueAutoDownloads());
-                              }
-                            : null,
-                      ),
+            padding: const EdgeInsets.fromLTRB(16, 8, 8, 4),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    l.absorbingManageQueue,
+                    style: tt.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
                     ),
                   ),
-                const SizedBox(width: 4),
-                Switch(
-                  value: _queueAutoDownload,
-                  onChanged: _queueDownloadSettingsLoaded
-                      ? _setQueueAutoDownload
-                      : null,
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 ),
-              ]),
-            ]),
-          ),
-        if (_queueMode != 'off')
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-            child: Row(children: [
-              Expanded(child: Text(l.showUpNextLabel,
-                  style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant))),
-              Switch(
-                value: _showUpNext,
-                onChanged: (v) {
-                  setState(() => _showUpNext = v);
-                  PlayerSettings.setShowUpNextLabel(v);
-                },
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-            ]),
-          ),
-        if (_queueMode == 'auto_next' && _currentPodcastShowId != null)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-            child: Row(children: [
-              Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                Text(l.reversePlayOrder,
-                    style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
-                Text(
-                  _podcastAdvanceDir == 'newest_first'
-                      ? l.episodeListPlaysNewerToOlder
-                      : l.episodeListPlaysOlderToNewer,
-                  style: tt.bodySmall?.copyWith(
-                      color: cs.onSurfaceVariant, fontSize: 11.5),
+                TextButton(
+                  onPressed: () {
+                    widget.lib.reorderAbsorbing(_order);
+                    Navigator.pop(context);
+                  },
+                  child: Text(l.absorbingDone),
                 ),
-              ])),
-              Switch(
-                value: _podcastAdvanceDir == 'newest_first',
-                onChanged: (v) async {
-                  final dir = v ? 'newest_first' : 'oldest_first';
-                  setState(() => _podcastAdvanceDir = dir);
-                  await PlayerSettings.setPodcastAdvanceDir(
-                      _currentPodcastShowId!, dir);
-                  unawaited(widget.lib.syncQueueAutoDownloads());
-                },
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ],
+            ),
+          ),
+          // Queue mode toggle
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 6),
+            child: SegmentedButton<String>(
+              segments: [
+                ButtonSegment(
+                  value: 'off',
+                  icon: const Icon(Icons.stop_rounded, size: 16),
+                  label: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(l.queueModeOff, maxLines: 1),
+                  ),
+                ),
+                ButtonSegment(
+                  value: 'manual',
+                  icon: const Icon(Icons.queue_music_rounded, size: 16),
+                  label: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(l.queueModeManual, maxLines: 1),
+                  ),
+                ),
+                ButtonSegment(
+                  value: 'auto_next',
+                  icon: const Icon(Icons.skip_next_rounded, size: 16),
+                  label: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      widget.isMerged
+                          ? l.queueModeAuto
+                          : _currentIsPodcast
+                          ? l.queueModeShowLabel
+                          : l.queueModeSeriesLabel,
+                      maxLines: 1,
+                    ),
+                  ),
+                ),
+                ButtonSegment(
+                  value: 'playlist',
+                  icon: const Icon(Icons.playlist_play_rounded, size: 16),
+                  label: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(l.queueModePlaylist, maxLines: 1),
+                  ),
+                ),
+                // Collection mode is entered via a collection's Play button, not
+                // picked here - shown only while active so the selection is valid.
+                if (_queueMode == 'collection')
+                  ButtonSegment(
+                    value: 'collection',
+                    icon: const Icon(
+                      Icons.collections_bookmark_rounded,
+                      size: 16,
+                    ),
+                    label: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(l.queueModeCollection, maxLines: 1),
+                    ),
+                  ),
+              ],
+              selected: {_queueMode},
+              onSelectionChanged: (v) {
+                if (v.isNotEmpty) widget.onQueueModeChanged(v.first);
+              },
+              style: ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
-            ]),
+            ),
           ),
-        if (_queueMode == 'auto_next' && !_currentIsPodcast && _seriesId != null)
-          _modeHeaderButton(
-            cs, tt,
-            label: l.openSeries,
-            subtitle: _seriesName,
-            icon: Icons.collections_bookmark_rounded,
-            onTap: () {
-              final auth = context.read<AuthProvider>();
-              final outer = rootNavigatorKey.currentContext ?? context;
-              Navigator.pop(context);
-              showSeriesBooksSheet(
-                outer,
-                seriesName: _seriesName ?? '',
-                seriesId: _seriesId,
-                books: const [],
-                serverUrl: auth.serverUrl,
-                token: auth.token,
-                libraryId: widget.lib.selectedLibraryId,
-              );
-            },
-          ),
-        if (_queueMode == 'auto_next' && _currentPodcastShowId != null && _showItem != null)
-          _modeHeaderButton(
-            cs, tt,
-            label: l.allEpisodes,
-            subtitle: _showName,
-            icon: Icons.podcasts_rounded,
-            onTap: () {
-              final outer = rootNavigatorKey.currentContext ?? context;
-              Navigator.pop(context);
-              EpisodeListSheet.show(outer, _showItem!);
-            },
-          ),
-        if (_queueMode == 'playlist' && _playlistId != null)
-          _modeHeaderButton(
-            cs, tt,
-            label: l.openPlaylist,
-            subtitle: _playlistName,
-            icon: Icons.playlist_play_rounded,
-            onTap: () {
-              final outer = rootNavigatorKey.currentContext ?? context;
-              Navigator.pop(context);
-              PlaylistDetailSheet.show(outer, _playlistId!);
-            },
-          ),
-        if (_queueMode == 'collection' && _collectionId != null)
-          _modeHeaderButton(
-            cs, tt,
-            label: l.openCollection,
-            subtitle: _collectionName,
-            icon: Icons.collections_bookmark_rounded,
-            onTap: () {
-              final outer = rootNavigatorKey.currentContext ?? context;
-              Navigator.pop(context);
-              CollectionDetailSheet.show(outer, _collectionId!);
-            },
-          ),
-        Expanded(
-          child: _buildQueueList(cs, tt, l, bottomInset),
-        ),
-      ]),
+          if (_queueMode != 'off')
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              _autoDownloadLabel(l),
+                              style: tt.bodySmall?.copyWith(
+                                color: cs.onSurfaceVariant,
+                              ),
+                            ),
+                            Text(
+                              _queueAutoDownload
+                                  ? l.autoDownloadQueueOnSubtitle(
+                                      _rollingDownloadCount,
+                                    )
+                                  : l.autoDownloadQueueOffSubtitle,
+                              style: tt.bodySmall?.copyWith(
+                                color: cs.onSurfaceVariant,
+                                fontSize: 11.5,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      if (_queueAutoDownload)
+                        Tooltip(
+                          message: l.keepNext,
+                          child: DropdownButtonHideUnderline(
+                            child: DropdownButton<int>(
+                              value: _rollingDownloadCount,
+                              isDense: true,
+                              items: const [2, 3, 4, 5]
+                                  .map(
+                                    (count) => DropdownMenuItem(
+                                      value: count,
+                                      child: Text('$count'),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: _queueDownloadSettingsLoaded
+                                  ? (value) async {
+                                      if (value == null) return;
+                                      setState(
+                                        () => _rollingDownloadCount = value,
+                                      );
+                                      await PlayerSettings.setRollingDownloadCount(
+                                        value,
+                                      );
+                                      unawaited(
+                                        widget.lib.syncQueueAutoDownloads(),
+                                      );
+                                    }
+                                  : null,
+                            ),
+                          ),
+                        ),
+                      const SizedBox(width: 4),
+                      Switch(
+                        value: _queueAutoDownload,
+                        onChanged: _queueDownloadSettingsLoaded
+                            ? _setQueueAutoDownload
+                            : null,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          if (_queueMode != 'off')
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      l.showUpNextLabel,
+                      style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                    ),
+                  ),
+                  Switch(
+                    value: _showUpNext,
+                    onChanged: (v) {
+                      setState(() => _showUpNext = v);
+                      PlayerSettings.setShowUpNextLabel(v);
+                    },
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ],
+              ),
+            ),
+          if (_queueMode == 'auto_next' && _currentPodcastShowId != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l.reversePlayOrder,
+                          style: tt.bodySmall?.copyWith(
+                            color: cs.onSurfaceVariant,
+                          ),
+                        ),
+                        Text(
+                          _podcastAdvanceDir == 'newest_first'
+                              ? l.episodeListPlaysNewerToOlder
+                              : l.episodeListPlaysOlderToNewer,
+                          style: tt.bodySmall?.copyWith(
+                            color: cs.onSurfaceVariant,
+                            fontSize: 11.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Switch(
+                    value: _podcastAdvanceDir == 'newest_first',
+                    onChanged: (v) async {
+                      final dir = v ? 'newest_first' : 'oldest_first';
+                      setState(() => _podcastAdvanceDir = dir);
+                      await PlayerSettings.setPodcastAdvanceDir(
+                        _currentPodcastShowId!,
+                        dir,
+                      );
+                      unawaited(widget.lib.syncQueueAutoDownloads());
+                    },
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ],
+              ),
+            ),
+          if (_queueMode == 'auto_next' &&
+              !_currentIsPodcast &&
+              _seriesId != null)
+            _modeHeaderButton(
+              cs,
+              tt,
+              label: l.openSeries,
+              subtitle: _seriesName,
+              icon: Icons.collections_bookmark_rounded,
+              onTap: () {
+                final auth = context.read<AuthProvider>();
+                final outer = rootNavigatorKey.currentContext ?? context;
+                Navigator.pop(context);
+                showSeriesBooksSheet(
+                  outer,
+                  seriesName: _seriesName ?? '',
+                  seriesId: _seriesId,
+                  books: const [],
+                  serverUrl: auth.serverUrl,
+                  token: auth.token,
+                  libraryId: widget.lib.selectedLibraryId,
+                );
+              },
+            ),
+          if (_queueMode == 'auto_next' &&
+              _currentPodcastShowId != null &&
+              _showItem != null)
+            _modeHeaderButton(
+              cs,
+              tt,
+              label: l.allEpisodes,
+              subtitle: _showName,
+              icon: Icons.podcasts_rounded,
+              onTap: () {
+                final outer = rootNavigatorKey.currentContext ?? context;
+                Navigator.pop(context);
+                EpisodeListSheet.show(outer, _showItem!);
+              },
+            ),
+          if (_queueMode == 'playlist' && _playlistId != null)
+            _modeHeaderButton(
+              cs,
+              tt,
+              label: l.openPlaylist,
+              subtitle: _playlistName,
+              icon: Icons.playlist_play_rounded,
+              onTap: () {
+                final outer = rootNavigatorKey.currentContext ?? context;
+                Navigator.pop(context);
+                PlaylistDetailSheet.show(outer, _playlistId!);
+              },
+            ),
+          if (_queueMode == 'collection' && _collectionId != null)
+            _modeHeaderButton(
+              cs,
+              tt,
+              label: l.openCollection,
+              subtitle: _collectionName,
+              icon: Icons.collections_bookmark_rounded,
+              onTap: () {
+                final outer = rootNavigatorKey.currentContext ?? context;
+                Navigator.pop(context);
+                CollectionDetailSheet.show(outer, _collectionId!);
+              },
+            ),
+          Expanded(child: _buildQueueList(cs, tt, l, bottomInset)),
+        ],
+      ),
     );
   }
 
@@ -1716,32 +2074,51 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
             color: cs.surfaceContainerHighest.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(12),
           ),
-          child: Row(children: [
-            Icon(icon, size: 18, color: cs.primary),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(label,
-                      style: tt.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),
-                  if (subtitle != null && subtitle.isNotEmpty)
-                    Text(subtitle,
+          child: Row(
+            children: [
+              Icon(icon, size: 18, color: cs.primary),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      label,
+                      style: tt.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (subtitle != null && subtitle.isNotEmpty)
+                      Text(
+                        subtitle,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
-                ],
+                        style: tt.bodySmall?.copyWith(
+                          color: cs.onSurfaceVariant,
+                        ),
+                      ),
+                  ],
+                ),
               ),
-            ),
-            Icon(Icons.chevron_right_rounded, size: 18, color: cs.onSurfaceVariant),
-          ]),
+              Icon(
+                Icons.chevron_right_rounded,
+                size: 18,
+                color: cs.onSurfaceVariant,
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildQueueList(ColorScheme cs, TextTheme tt, AppLocalizations l, double bottomInset) {
+  Widget _buildQueueList(
+    ColorScheme cs,
+    TextTheme tt,
+    AppLocalizations l,
+    double bottomInset,
+  ) {
     if (_queueMode == 'auto_next') {
       if (_currentPodcastShowId != null) {
         return _buildShowEpisodesList(cs, tt, l, bottomInset);
@@ -1762,7 +2139,12 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     return _buildManualList(cs, tt, l, bottomInset);
   }
 
-  Widget _buildCollectionList(ColorScheme cs, TextTheme tt, AppLocalizations l, double bottomInset) {
+  Widget _buildCollectionList(
+    ColorScheme cs,
+    TextTheme tt,
+    AppLocalizations l,
+    double bottomInset,
+  ) {
     final books = _collectionBooks;
     if (books == null) {
       return const Center(child: CircularProgressIndicator(strokeWidth: 2));
@@ -1771,8 +2153,10 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text(l.absorbingNothingAbsorbingYet,
-              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant)),
+          child: Text(
+            l.absorbingNothingAbsorbingYet,
+            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
         ),
       );
     }
@@ -1788,7 +2172,12 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     );
   }
 
-  Widget _buildShowEpisodesList(ColorScheme cs, TextTheme tt, AppLocalizations l, double bottomInset) {
+  Widget _buildShowEpisodesList(
+    ColorScheme cs,
+    TextTheme tt,
+    AppLocalizations l,
+    double bottomInset,
+  ) {
     final eps = _showEpisodes;
     if (eps == null) {
       return const Center(child: CircularProgressIndicator(strokeWidth: 2));
@@ -1797,14 +2186,17 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text(l.absorbingNothingAbsorbingYet,
-              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant)),
+          child: Text(
+            l.absorbingNothingAbsorbingYet,
+            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
         ),
       );
     }
     final showId = _currentPodcastShowId;
     final newestFirst = _podcastAdvanceDir == 'newest_first';
-    final sorted = [...eps]..sort((a, b) {
+    final sorted = [...eps]
+      ..sort((a, b) {
         final at = (a['publishedAt'] as num?)?.toInt() ?? 0;
         final bt = (b['publishedAt'] as num?)?.toInt() ?? 0;
         return newestFirst ? bt.compareTo(at) : at.compareTo(bt);
@@ -1817,7 +2209,9 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
         final ep = sorted[i];
         final epId = ep['id'] as String? ?? '';
         return _readOnlyQueueItem(
-          cs, tt, l,
+          cs,
+          tt,
+          l,
           key: '$showId-$epId',
           book: _showItem ?? const {},
           index: i,
@@ -1827,7 +2221,12 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     );
   }
 
-  Widget _buildSeriesList(ColorScheme cs, TextTheme tt, AppLocalizations l, double bottomInset) {
+  Widget _buildSeriesList(
+    ColorScheme cs,
+    TextTheme tt,
+    AppLocalizations l,
+    double bottomInset,
+  ) {
     final books = _seriesBooks;
     if (books == null) {
       return const Center(child: CircularProgressIndicator(strokeWidth: 2));
@@ -1836,19 +2235,13 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text(l.absorbingNothingAbsorbingYet,
-              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant)),
+          child: Text(
+            l.absorbingNothingAbsorbingYet,
+            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
         ),
       );
     }
-    // Sort by series sequence (numeric leading).
-    books.sort((a, b) {
-      double seqOf(Map<String, dynamic> book) {
-        final (_, seq) = widget.lib.extractSeries(book);
-        return seq ?? double.maxFinite;
-      }
-      return seqOf(a).compareTo(seqOf(b));
-    });
     return ListView.builder(
       controller: widget.scrollController,
       padding: EdgeInsets.only(bottom: bottomInset + 16),
@@ -1861,7 +2254,12 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
     );
   }
 
-  Widget _buildPlaylistList(ColorScheme cs, TextTheme tt, AppLocalizations l, double bottomInset) {
+  Widget _buildPlaylistList(
+    ColorScheme cs,
+    TextTheme tt,
+    AppLocalizations l,
+    double bottomInset,
+  ) {
     final items = _playlistItems;
     if (items == null) {
       return const Center(child: CircularProgressIndicator(strokeWidth: 2));
@@ -1870,8 +2268,10 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text(l.playlistAllFinished,
-              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant)),
+          child: Text(
+            l.playlistAllFinished,
+            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
         ),
       );
     }
@@ -1883,10 +2283,14 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
         final item = items[i];
         final libraryItemId = item['libraryItemId'] as String? ?? '';
         final episodeId = item['episodeId'] as String?;
-        final key = episodeId != null ? '$libraryItemId-$episodeId' : libraryItemId;
+        final key = episodeId != null
+            ? '$libraryItemId-$episodeId'
+            : libraryItemId;
         final book = item['libraryItem'] as Map<String, dynamic>? ?? const {};
         return _readOnlyQueueItem(
-          cs, tt, l,
+          cs,
+          tt,
+          l,
           key: key,
           book: book,
           index: i,
@@ -1959,11 +2363,13 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
               title: epTitle ?? title,
               author: title,
               coverUrl: widget.lib.getCoverUrl(showId),
-              totalDuration: (episodeOverride?['duration'] as num?)?.toDouble() ?? 0,
+              totalDuration:
+                  (episodeOverride?['duration'] as num?)?.toDouble() ?? 0,
               chapters: const [],
               episodeId: epId,
               episodeTitle: epTitle,
-              libraryId: book['libraryId'] as String? ?? widget.lib.selectedLibraryId,
+              libraryId:
+                  book['libraryId'] as String? ?? widget.lib.selectedLibraryId,
               fromUi: true,
             );
           } else {
@@ -1975,205 +2381,278 @@ class _ReorderAbsorbingSheetState extends State<_ReorderAbsorbingSheet> {
               coverUrl: widget.lib.getCoverUrl(key),
               totalDuration: (media['duration'] as num?)?.toDouble() ?? 0,
               chapters: media['chapters'] as List<dynamic>? ?? const [],
-              libraryId: book['libraryId'] as String? ?? widget.lib.selectedLibraryId,
+              libraryId:
+                  book['libraryId'] as String? ?? widget.lib.selectedLibraryId,
               fromUi: true,
             );
           }
-          unawaited(playback.then((error) async {
-            if (error == null) {
-              await widget.lib.syncQueueAutoDownloads();
-            }
-          }));
+          unawaited(
+            playback.then((error) async {
+              if (error == null) {
+                await widget.lib.syncQueueAutoDownloads();
+              }
+            }),
+          );
         },
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
           decoration: BoxDecoration(
             color: isPlaying
                 ? cs.primaryContainer.withValues(alpha: 0.25)
-                : (isFinished ? cs.onSurface.withValues(alpha: 0.03) : Colors.transparent),
+                : (isFinished
+                      ? cs.onSurface.withValues(alpha: 0.03)
+                      : Colors.transparent),
             borderRadius: BorderRadius.circular(12),
           ),
-          child: Row(children: [
-            SizedBox(
-              width: 24,
-              child: Text('${index + 1}',
+          child: Row(
+            children: [
+              SizedBox(
+                width: 24,
+                child: Text(
+                  '${index + 1}',
                   style: tt.labelMedium?.copyWith(
-                    color: isFinished ? cs.onSurface.withValues(alpha: 0.3) : cs.primary,
+                    color: isFinished
+                        ? cs.onSurface.withValues(alpha: 0.3)
+                        : cs.primary,
                     fontWeight: FontWeight.w700,
-                  )),
-            ),
-            if (isFinished)
-              Icon(Icons.check_circle_rounded,
-                  size: 16, color: Colors.green.withValues(alpha: 0.5))
-            else
-              () {
-                final progress = widget.lib.getProgress(key);
-                return progress > 0
-                    ? SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(
-                          value: progress,
-                          strokeWidth: 2.5,
-                          backgroundColor: cs.surfaceContainerHighest,
-                          color: cs.primary,
-                        ),
-                      )
-                    : Icon(Icons.circle_outlined,
-                        size: 16, color: cs.onSurface.withValues(alpha: 0.2));
-              }(),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(epTitle ?? title,
+                  ),
+                ),
+              ),
+              if (isFinished)
+                Icon(
+                  Icons.check_circle_rounded,
+                  size: 16,
+                  color: Colors.green.withValues(alpha: 0.5),
+                )
+              else
+                () {
+                  final progress = widget.lib.getProgress(key);
+                  return progress > 0
+                      ? SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            value: progress,
+                            strokeWidth: 2.5,
+                            backgroundColor: cs.surfaceContainerHighest,
+                            color: cs.primary,
+                          ),
+                        )
+                      : Icon(
+                          Icons.circle_outlined,
+                          size: 16,
+                          color: cs.onSurface.withValues(alpha: 0.2),
+                        );
+                }(),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      epTitle ?? title,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: tt.bodyMedium?.copyWith(
                         color: isFinished
                             ? cs.onSurface.withValues(alpha: 0.4)
                             : null,
-                      )),
-                  if (epTitle != null)
-                    Text(title,
+                      ),
+                    ),
+                    if (epTitle != null)
+                      Text(
+                        title,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant))
-                  else if (author.isNotEmpty)
-                    Text(author,
+                        style: tt.bodySmall?.copyWith(
+                          color: cs.onSurfaceVariant,
+                        ),
+                      )
+                    else if (author.isNotEmpty)
+                      Text(
+                        author,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
-                ],
+                        style: tt.bodySmall?.copyWith(
+                          color: cs.onSurfaceVariant,
+                        ),
+                      ),
+                  ],
+                ),
               ),
-            ),
-            _downloadStatus(key, cs),
-          ]),
+              _downloadStatus(key, cs),
+            ],
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildManualList(ColorScheme cs, TextTheme tt, AppLocalizations l, double bottomInset) {
+  Widget _buildManualList(
+    ColorScheme cs,
+    TextTheme tt,
+    AppLocalizations l,
+    double bottomInset,
+  ) {
     return ReorderableListView.builder(
-            scrollController: widget.scrollController,
-            buildDefaultDragHandles: false,
-            onReorderStart: (_) => HapticFeedback.mediumImpact(),
-            padding: EdgeInsets.only(bottom: bottomInset + 16),
-            proxyDecorator: (child, index, animation) {
-              return AnimatedBuilder(
-                animation: animation,
-                builder: (context, child) => Material(
-                  elevation: 4,
-                  borderRadius: BorderRadius.circular(12),
-                  color: cs.surfaceContainer,
-                  child: child,
-                ),
-                child: child,
-              );
-            },
-            itemCount: _order.length,
-            onReorder: (oldIdx, newIdx) {
-              setState(() {
-                if (newIdx > oldIdx) newIdx--;
-                final item = _order.removeAt(oldIdx);
-                _order.insert(newIdx, item);
-              });
-            },
-            itemBuilder: (context, i) {
-              final key = _order[i];
-              final book = _booksByKey[key];
-              if (book == null) return SizedBox.shrink(key: ValueKey(key));
+      scrollController: widget.scrollController,
+      buildDefaultDragHandles: false,
+      onReorderStart: (_) => HapticFeedback.mediumImpact(),
+      padding: EdgeInsets.only(bottom: bottomInset + 16),
+      proxyDecorator: (child, index, animation) {
+        return AnimatedBuilder(
+          animation: animation,
+          builder: (context, child) => Material(
+            elevation: 4,
+            borderRadius: BorderRadius.circular(12),
+            color: cs.surfaceContainer,
+            child: child,
+          ),
+          child: child,
+        );
+      },
+      itemCount: _order.length,
+      onReorder: (oldIdx, newIdx) {
+        setState(() {
+          if (newIdx > oldIdx) newIdx--;
+          final item = _order.removeAt(oldIdx);
+          _order.insert(newIdx, item);
+        });
+      },
+      itemBuilder: (context, i) {
+        final key = _order[i];
+        final book = _booksByKey[key];
+        if (book == null) return SizedBox.shrink(key: ValueKey(key));
 
-              final media = book['media'] as Map<String, dynamic>? ?? {};
-              final metadata = media['metadata'] as Map<String, dynamic>? ?? {};
-              final title = metadata['title'] as String? ?? l.unknown;
-              final author = metadata['authorName'] as String? ?? '';
-              final re = book['recentEpisode'] as Map<String, dynamic>?;
-              final epTitle = re?['title'] as String?;
-              final isFinished = widget.lib.isItemFinishedByKey(key);
+        final media = book['media'] as Map<String, dynamic>? ?? {};
+        final metadata = media['metadata'] as Map<String, dynamic>? ?? {};
+        final title = metadata['title'] as String? ?? l.unknown;
+        final author = metadata['authorName'] as String? ?? '';
+        final re = book['recentEpisode'] as Map<String, dynamic>?;
+        final epTitle = re?['title'] as String?;
+        final isFinished = widget.lib.isItemFinishedByKey(key);
 
-              return Dismissible(
-                key: ValueKey(key),
-                direction: DismissDirection.endToStart,
-                background: Container(
-                  alignment: Alignment.centerRight,
-                  padding: const EdgeInsets.only(right: 24),
-                  margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
-                  decoration: BoxDecoration(
-                    color: cs.error.withValues(alpha: 0.12),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Icon(Icons.remove_circle_outline_rounded, color: cs.error),
-                ),
-                onDismissed: (_) {
-                  final removedKey = _order[i];
-                  setState(() => _order.removeAt(i));
-                  widget.lib.removeFromAbsorbing(removedKey);
-                  widget.lib.reorderAbsorbing(_order);
-                },
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                    decoration: BoxDecoration(
-                      color: isFinished ? cs.onSurface.withValues(alpha: 0.03) : Colors.transparent,
-                      borderRadius: BorderRadius.circular(12),
+        return Dismissible(
+          key: ValueKey(key),
+          direction: DismissDirection.endToStart,
+          background: Container(
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.only(right: 24),
+            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+            decoration: BoxDecoration(
+              color: cs.error.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(Icons.remove_circle_outline_rounded, color: cs.error),
+          ),
+          onDismissed: (_) {
+            final removedKey = _order[i];
+            setState(() => _order.removeAt(i));
+            widget.lib.removeFromAbsorbing(removedKey);
+            widget.lib.reorderAbsorbing(_order);
+          },
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              decoration: BoxDecoration(
+                color: isFinished
+                    ? cs.onSurface.withValues(alpha: 0.03)
+                    : Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Row(
+                children: [
+                  // Queue position number
+                  SizedBox(
+                    width: 24,
+                    child: Text(
+                      '${i + 1}',
+                      style: tt.labelMedium?.copyWith(
+                        color: isFinished
+                            ? cs.onSurface.withValues(alpha: 0.3)
+                            : cs.primary,
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
-                    child: Row(children: [
-                      // Queue position number
-                      SizedBox(width: 24, child: Text('${i + 1}',
-                        style: tt.labelMedium?.copyWith(
-                          color: isFinished ? cs.onSurface.withValues(alpha: 0.3) : cs.primary,
-                          fontWeight: FontWeight.w700,
-                        ))),
-                      // Progress indicator
-                      if (isFinished)
-                        Icon(Icons.check_circle_rounded, size: 16, color: Colors.green.withValues(alpha: 0.5))
-                      else ...[
-                        () {
-                          final progress = widget.lib.getProgress(key);
-                          return progress > 0
-                              ? SizedBox(width: 16, height: 16,
-                                  child: CircularProgressIndicator(
-                                    value: progress,
-                                    strokeWidth: 2.5,
-                                    backgroundColor: cs.surfaceContainerHighest,
-                                    color: cs.primary,
-                                  ))
-                              : Icon(Icons.circle_outlined, size: 16, color: cs.onSurface.withValues(alpha: 0.2));
-                        }(),
-                      ],
-                      const SizedBox(width: 8),
-                      // Title + subtitle
-                      Expanded(child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(epTitle ?? title,
-                            maxLines: 1, overflow: TextOverflow.ellipsis,
-                            style: tt.bodyMedium?.copyWith(
-                              color: isFinished ? cs.onSurface.withValues(alpha: 0.4) : null,
-                            )),
-                          if (epTitle != null)
-                            Text(title, maxLines: 1, overflow: TextOverflow.ellipsis,
-                              style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
-                          if (author.isNotEmpty && epTitle == null)
-                            Text(author, maxLines: 1, overflow: TextOverflow.ellipsis,
-                              style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
-                        ],
-                      )),
-                      _downloadStatus(key, cs),
-                      // Drag handle (long-press to avoid conflict with system home gesture)
-                      _DragHandle(index: i, color: cs.onSurface),
-                    ]),
                   ),
-                ),
-              );
-            },
-          );
+                  // Progress indicator
+                  if (isFinished)
+                    Icon(
+                      Icons.check_circle_rounded,
+                      size: 16,
+                      color: Colors.green.withValues(alpha: 0.5),
+                    )
+                  else ...[
+                    () {
+                      final progress = widget.lib.getProgress(key);
+                      return progress > 0
+                          ? SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                value: progress,
+                                strokeWidth: 2.5,
+                                backgroundColor: cs.surfaceContainerHighest,
+                                color: cs.primary,
+                              ),
+                            )
+                          : Icon(
+                              Icons.circle_outlined,
+                              size: 16,
+                              color: cs.onSurface.withValues(alpha: 0.2),
+                            );
+                    }(),
+                  ],
+                  const SizedBox(width: 8),
+                  // Title + subtitle
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          epTitle ?? title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: tt.bodyMedium?.copyWith(
+                            color: isFinished
+                                ? cs.onSurface.withValues(alpha: 0.4)
+                                : null,
+                          ),
+                        ),
+                        if (epTitle != null)
+                          Text(
+                            title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: tt.bodySmall?.copyWith(
+                              color: cs.onSurfaceVariant,
+                            ),
+                          ),
+                        if (author.isNotEmpty && epTitle == null)
+                          Text(
+                            author,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: tt.bodySmall?.copyWith(
+                              color: cs.onSurfaceVariant,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  _downloadStatus(key, cs),
+                  // Drag handle (long-press to avoid conflict with system home gesture)
+                  _DragHandle(index: i, color: cs.onSurface),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }
 }
 
@@ -2188,7 +2667,8 @@ class _DragHandle extends StatefulWidget {
   State<_DragHandle> createState() => _DragHandleState();
 }
 
-class _DragHandleState extends State<_DragHandle> with SingleTickerProviderStateMixin {
+class _DragHandleState extends State<_DragHandle>
+    with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   // Match ReorderableDelayedDragStartListener's default delay
   static const _holdDuration = Duration(milliseconds: 500);
@@ -2235,11 +2715,16 @@ class _DragHandleState extends State<_DragHandle> with SingleTickerProviderState
               duration: const Duration(milliseconds: 150),
               padding: const EdgeInsets.all(6),
               decoration: BoxDecoration(
-                color: ready ? widget.color.withValues(alpha: 0.1) : Colors.transparent,
+                color: ready
+                    ? widget.color.withValues(alpha: 0.1)
+                    : Colors.transparent,
                 borderRadius: BorderRadius.circular(8),
               ),
-              child: Icon(Icons.drag_handle_rounded, size: 20,
-                color: widget.color.withValues(alpha: ready ? 0.7 : 0.3)),
+              child: Icon(
+                Icons.drag_handle_rounded,
+                size: 20,
+                color: widget.color.withValues(alpha: ready ? 0.7 : 0.3),
+              ),
             );
           },
         ),

--- a/lib/widgets/series_books_sheet.dart
+++ b/lib/widgets/series_books_sheet.dart
@@ -25,7 +25,8 @@ import '../utils/duration_format.dart';
 
 /// Show a bottom sheet with all books in a series, sorted by sequence.
 /// Can be called from any screen.
-void showSeriesBooksSheet(BuildContext context, {
+void showSeriesBooksSheet(
+  BuildContext context, {
   required String seriesName,
   String? seriesId,
   List<dynamic> books = const [],
@@ -112,7 +113,7 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     _sortBooks();
     if (_books.isNotEmpty) {
       _isLoading = false;
-      _scrollToUpNext();
+      _scrollToCurrentOrUpNext();
     }
     // Fetch full data from API for proper sequence info
     _fetchFromApi();
@@ -145,37 +146,55 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
   void _onLibraryChanged() {
     // Just rebuild to pick up progress/cover changes — don't re-fetch
     if (mounted) {
-      try { setState(() {}); } catch (_) {}
+      try {
+        setState(() {});
+      } catch (_) {}
     }
   }
 
-  void _scrollToUpNext() {
+  void _scrollToCurrentOrUpNext({bool allowFallback = false, int retries = 2}) {
     if (_didAutoScroll || _books.isEmpty) return;
-    _didAutoScroll = true;
-    final lib = context.read<LibraryProvider>();
-    int firstUnfinished = -1;
-    for (int i = 0; i < _books.length; i++) {
-      final bookId = _books[i]['id'] as String? ?? '';
-      if (lib.getProgressData(bookId)?['isFinished'] != true) {
-        firstUnfinished = i;
-        break;
-      }
+    final activeItemId = AudioPlayerService().currentItemId;
+    var targetIndex = activeItemId == null
+        ? -1
+        : _books.indexWhere((book) => book['id'] == activeItemId);
+    if (targetIndex < 0 && !allowFallback) return;
+    if (targetIndex < 0) {
+      final lib = context.read<LibraryProvider>();
+      targetIndex = _books.indexWhere(
+        (book) =>
+            lib.getProgressData(book['id'] as String?)?['isFinished'] != true,
+      );
+      if (targetIndex < 0) targetIndex = _books.length - 1;
     }
-    // If all finished, scroll to bottom; if first is unfinished, stay at top
-    final targetIndex = firstUnfinished == -1 ? _books.length - 1 : firstUnfinished;
-    if (targetIndex <= 0) return;
+    if (targetIndex == 0) {
+      _didAutoScroll = true;
+      return;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !widget.scrollController.hasClients) return;
-      // Each book card is ~120px (112 height + 8 bottom padding)
-      final offset = (targetIndex * 120.0).clamp(
-        0.0,
-        widget.scrollController.position.maxScrollExtent,
-      );
-      widget.scrollController.animateTo(
-        offset,
-        duration: const Duration(milliseconds: 400),
-        curve: Curves.easeOutCubic,
-      );
+      if (!mounted || _didAutoScroll) return;
+      final controller = widget.scrollController;
+      if (!controller.hasClients) {
+        if (retries > 0) {
+          _scrollToCurrentOrUpNext(
+            allowFallback: allowFallback,
+            retries: retries - 1,
+          );
+        }
+        return;
+      }
+      // Book cards are 112px high with 8px spacing. Center the selected book
+      // once the full list is available; partial pages must not pick a false
+      // "next" item near the beginning or end of a large series.
+      const itemExtent = 120.0;
+      final position = controller.position;
+      final offset =
+          (targetIndex * itemExtent -
+                  position.viewportDimension / 2 +
+                  itemExtent / 2)
+              .clamp(0.0, position.maxScrollExtent);
+      controller.jumpTo(offset);
+      _didAutoScroll = true;
     });
   }
 
@@ -196,8 +215,11 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     final result = <Map<String, dynamic>>[];
     for (final b in raw) {
       if (b is! Map<String, dynamic>) continue;
-      if (b.containsKey('libraryItem') && b['libraryItem'] is Map<String, dynamic>) {
-        final item = Map<String, dynamic>.from(b['libraryItem'] as Map<String, dynamic>);
+      if (b.containsKey('libraryItem') &&
+          b['libraryItem'] is Map<String, dynamic>) {
+        final item = Map<String, dynamic>.from(
+          b['libraryItem'] as Map<String, dynamic>,
+        );
         if (b['sequence'] != null) item['sequence'] = b['sequence'];
         if (lib != null) registerBookCover(lib, item);
         result.add(item);
@@ -238,7 +260,8 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
           return s['sequence'].toString();
         }
       }
-    } else if (seriesRaw is Map<String, dynamic> && seriesRaw['sequence'] != null) {
+    } else if (seriesRaw is Map<String, dynamic> &&
+        seriesRaw['sequence'] != null) {
       return seriesRaw['sequence'].toString();
     }
     final fallback = metadata['seriesSequence'];
@@ -305,7 +328,9 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     final seriesRaw = metadata['series'];
     final list = seriesRaw is List
         ? seriesRaw.whereType<Map<String, dynamic>>()
-        : seriesRaw is Map<String, dynamic> ? [seriesRaw] : const <Map<String, dynamic>>[];
+        : seriesRaw is Map<String, dynamic>
+        ? [seriesRaw]
+        : const <Map<String, dynamic>>[];
     for (final s in list) {
       if ((s['id'] as String? ?? '') == subId && s['sequence'] != null) {
         return s['sequence'].toString();
@@ -336,9 +361,12 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     // Check cache first
     final seriesId = widget.seriesId;
     if (seriesId != null) {
-      final cached = context.read<LibraryProvider>().getSubSeriesCache(seriesId);
+      final cached = context.read<LibraryProvider>().getSubSeriesCache(
+        seriesId,
+      );
       if (cached != null) {
-        _subSeriesList = (cached['subSeries'] as List<Map<String, dynamic>>?) ?? [];
+        _subSeriesList =
+            (cached['subSeries'] as List<Map<String, dynamic>>?) ?? [];
         _assignedBookIds = (cached['assignedIds'] as Set<String>?) ?? {};
         _subSeriesLoaded = true;
         if (mounted) setState(() {});
@@ -353,7 +381,13 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     _subSeriesLoaded = true;
     // Cache the results
     if (seriesId != null) {
-      try { context.read<LibraryProvider>().setSubSeriesCache(seriesId, _subSeriesList, _assignedBookIds); } catch (_) {}
+      try {
+        context.read<LibraryProvider>().setSubSeriesCache(
+          seriesId,
+          _subSeriesList,
+          _assignedBookIds,
+        );
+      } catch (_) {}
     }
     if (mounted) setState(() {});
   }
@@ -368,36 +402,51 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
 
     for (var i = 0; i < _books.length; i += 10) {
       final batch = _books.skip(i).take(10);
-      await Future.wait(batch.map((book) async {
-        final bookId = book['id'] as String? ?? '';
-        if (bookId.isEmpty) return;
-        final fullItem = await api.getLibraryItem(bookId);
-        if (fullItem == null) return;
-        final media = fullItem['media'] as Map<String, dynamic>? ?? {};
-        final metadata = media['metadata'] as Map<String, dynamic>? ?? {};
-        final seriesRaw = metadata['series'];
-        final seriesList = seriesRaw is List
-            ? seriesRaw.whereType<Map<String, dynamic>>().toList()
-            : seriesRaw is Map<String, dynamic> ? [seriesRaw] : <Map<String, dynamic>>[];
+      await Future.wait(
+        batch.map((book) async {
+          final bookId = book['id'] as String? ?? '';
+          if (bookId.isEmpty) return;
+          final fullItem = await api.getLibraryItem(bookId);
+          if (fullItem == null) return;
+          final media = fullItem['media'] as Map<String, dynamic>? ?? {};
+          final metadata = media['metadata'] as Map<String, dynamic>? ?? {};
+          final seriesRaw = metadata['series'];
+          final seriesList = seriesRaw is List
+              ? seriesRaw.whereType<Map<String, dynamic>>().toList()
+              : seriesRaw is Map<String, dynamic>
+              ? [seriesRaw]
+              : <Map<String, dynamic>>[];
 
-        for (final s in seriesList) {
-          final sId = s['id'] as String? ?? '';
-          final sName = s['name'] as String? ?? '';
-          if (sId == currentId || sId == widget.parentSeriesId || sName.toLowerCase() == currentName || sId.isEmpty) continue;
-          subSeriesMap.putIfAbsent(sId, () => {
-            'name': sName, 'id': sId, 'books': <Map<String, dynamic>>[], 'numBooks': 0,
-          });
-          final books = subSeriesMap[sId]!['books'] as List<Map<String, dynamic>>;
-          if (!books.any((b) => b['id'] == bookId)) {
-            // Store the sub-series sequence on the book for sorting
-            final subSeq = s['sequence']?.toString();
-            final bookCopy = Map<String, dynamic>.from(book);
-            if (subSeq != null) bookCopy['_subSequence'] = subSeq;
-            books.add(bookCopy);
-            subSeriesMap[sId]!['numBooks'] = books.length;
+          for (final s in seriesList) {
+            final sId = s['id'] as String? ?? '';
+            final sName = s['name'] as String? ?? '';
+            if (sId == currentId ||
+                sId == widget.parentSeriesId ||
+                sName.toLowerCase() == currentName ||
+                sId.isEmpty)
+              continue;
+            subSeriesMap.putIfAbsent(
+              sId,
+              () => {
+                'name': sName,
+                'id': sId,
+                'books': <Map<String, dynamic>>[],
+                'numBooks': 0,
+              },
+            );
+            final books =
+                subSeriesMap[sId]!['books'] as List<Map<String, dynamic>>;
+            if (!books.any((b) => b['id'] == bookId)) {
+              // Store the sub-series sequence on the book for sorting
+              final subSeq = s['sequence']?.toString();
+              final bookCopy = Map<String, dynamic>.from(book);
+              if (subSeq != null) bookCopy['_subSequence'] = subSeq;
+              books.add(bookCopy);
+              subSeriesMap[sId]!['numBooks'] = books.length;
+            }
           }
-        }
-      }));
+        }),
+      );
     }
 
     subSeriesMap.removeWhere((_, v) => (v['numBooks'] as int) < 2);
@@ -407,18 +456,26 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     }
     _subSeriesList = subSeriesMap.values.toList();
     _assignedBookIds = _subSeriesList
-        .expand((s) => (s['books'] as List<Map<String, dynamic>>).map((b) => b['id'] as String? ?? ''))
+        .expand(
+          (s) => (s['books'] as List<Map<String, dynamic>>).map(
+            (b) => b['id'] as String? ?? '',
+          ),
+        )
         .toSet();
   }
 
   /// Large series: use collapseseries=1 API (one request, server groups them).
   Future<void> _loadSubSeriesFromCollapsed() async {
     final seriesId = widget.seriesId;
-    final libraryId = widget.libraryId ?? context.read<LibraryProvider>().selectedLibraryId;
+    final libraryId =
+        widget.libraryId ?? context.read<LibraryProvider>().selectedLibraryId;
     if (seriesId == null || libraryId == null) return;
     final api = context.read<AuthProvider>().apiService;
     if (api == null) return;
-    final results = await api.getSeriesCollapsed(seriesId, libraryId: libraryId);
+    final results = await api.getSeriesCollapsed(
+      seriesId,
+      libraryId: libraryId,
+    );
     final byId = {for (final b in _books) (b['id'] as String? ?? ''): b};
 
     for (final raw in results) {
@@ -427,7 +484,8 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
       if (collapsed == null) continue;
       final subId = collapsed['id'] as String? ?? '';
       final subName = collapsed['name'] as String? ?? '';
-      final itemIds = (collapsed['libraryItemIds'] as List<dynamic>?)?.cast<String>() ?? [];
+      final itemIds =
+          (collapsed['libraryItemIds'] as List<dynamic>?)?.cast<String>() ?? [];
       final matchingBooks = <Map<String, dynamic>>[];
       for (final id in itemIds) {
         final original = byId[id];
@@ -448,16 +506,28 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
         'name': subName,
         'id': subId,
         'books': matchingBooks,
-        'numBooks': (collapsed['numBooks'] as int? ?? 0) > 0 ? collapsed['numBooks'] as int : itemIds.length,
+        'numBooks': (collapsed['numBooks'] as int? ?? 0) > 0
+            ? collapsed['numBooks'] as int
+            : itemIds.length,
       });
       _assignedBookIds.addAll(itemIds);
     }
   }
 
-  ({List<Map<String, dynamic>> subSeries, List<Map<String, dynamic>> standalone}) _buildSubSeriesGroups() {
+  ({
+    List<Map<String, dynamic>> subSeries,
+    List<Map<String, dynamic>> standalone,
+  })
+  _buildSubSeriesGroups() {
     final subSeries = List<Map<String, dynamic>>.from(_subSeriesList)
-      ..sort((a, b) => (a['name'] as String).toLowerCase().compareTo((b['name'] as String).toLowerCase()));
-    final standalone = _books.where((b) => !_assignedBookIds.contains(b['id'] as String? ?? '')).toList();
+      ..sort(
+        (a, b) => (a['name'] as String).toLowerCase().compareTo(
+          (b['name'] as String).toLowerCase(),
+        ),
+      );
+    final standalone = _books
+        .where((b) => !_assignedBookIds.contains(b['id'] as String? ?? ''))
+        .toList();
     return (subSeries: subSeries, standalone: standalone);
   }
 
@@ -466,15 +536,26 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
 
     return GridView.builder(
       controller: widget.scrollController,
-      padding: EdgeInsets.fromLTRB(16, 0, 16, 24 + MediaQuery.of(context).viewPadding.bottom),
+      padding: EdgeInsets.fromLTRB(
+        16,
+        0,
+        16,
+        24 + MediaQuery.of(context).viewPadding.bottom,
+      ),
       gridDelegate: sheetBookGridDelegate(context, childAspectRatio: 0.65),
       itemCount: parsed.subSeries.length + parsed.standalone.length,
       itemBuilder: (context, index) {
         if (index < parsed.subSeries.length) {
-          return GridSeriesTileDirect(series: parsed.subSeries[index], parentSeriesId: widget.seriesId);
+          return GridSeriesTileDirect(
+            series: parsed.subSeries[index],
+            parentSeriesId: widget.seriesId,
+          );
         }
         final book = parsed.standalone[index - parsed.subSeries.length];
-        return GridBookTile(item: book, sequenceBadge: _getSequenceString(book));
+        return GridBookTile(
+          item: book,
+          sequenceBadge: _getSequenceString(book),
+        );
       },
     );
   }
@@ -485,7 +566,12 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
 
     return ListView(
       controller: widget.scrollController,
-      padding: EdgeInsets.fromLTRB(16, 0, 16, 24 + MediaQuery.of(context).viewPadding.bottom),
+      padding: EdgeInsets.fromLTRB(
+        16,
+        0,
+        16,
+        24 + MediaQuery.of(context).viewPadding.bottom,
+      ),
       children: [
         // Sub-series headers
         for (final series in parsed.subSeries) ...[
@@ -505,37 +591,78 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
                 children: [
                   GestureDetector(
                     onTap: () => setState(() {
-                      if (isExpanded) _expandedSubSeries.remove(seriesId);
-                      else _expandedSubSeries.add(seriesId);
+                      if (isExpanded)
+                        _expandedSubSeries.remove(seriesId);
+                      else
+                        _expandedSubSeries.add(seriesId);
                     }),
-                    onLongPress: seriesId.isNotEmpty ? () {
-                      showSeriesBooksSheet(context,
-                        seriesName: seriesName, seriesId: seriesId,
-                        serverUrl: widget.serverUrl, token: widget.token, libraryId: widget.libraryId,
-                        parentSeriesId: widget.seriesId);
-                    } : null,
+                    onLongPress: seriesId.isNotEmpty
+                        ? () {
+                            showSeriesBooksSheet(
+                              context,
+                              seriesName: seriesName,
+                              seriesId: seriesId,
+                              serverUrl: widget.serverUrl,
+                              token: widget.token,
+                              libraryId: widget.libraryId,
+                              parentSeriesId: widget.seriesId,
+                            );
+                          }
+                        : null,
                     child: Container(
                       margin: const EdgeInsets.only(bottom: 8, top: 4),
-                      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                      decoration: BoxDecoration(color: cs.surfaceContainerHigh, borderRadius: BorderRadius.circular(12)),
-                      child: Row(children: [
-                        AnimatedRotation(
-                          turns: isExpanded ? 0.5 : 0.0,
-                          duration: const Duration(milliseconds: 250),
-                          child: Icon(Icons.expand_more_rounded, size: 20, color: cs.onSurfaceVariant),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                          Text(seriesName, style: tt.bodyMedium?.copyWith(fontWeight: FontWeight.w600, color: cs.onSurface)),
-                          const SizedBox(height: 2),
-                          Text(l.seriesBooksBookCount(numBooks),
-                            style: tt.labelSmall?.copyWith(color: cs.onSurfaceVariant.withValues(alpha: 0.5), fontSize: 11)),
-                        ])),
-                      ]),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 10,
+                      ),
+                      decoration: BoxDecoration(
+                        color: cs.surfaceContainerHigh,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Row(
+                        children: [
+                          AnimatedRotation(
+                            turns: isExpanded ? 0.5 : 0.0,
+                            duration: const Duration(milliseconds: 250),
+                            child: Icon(
+                              Icons.expand_more_rounded,
+                              size: 20,
+                              color: cs.onSurfaceVariant,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  seriesName,
+                                  style: tt.bodyMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                    color: cs.onSurface,
+                                  ),
+                                ),
+                                const SizedBox(height: 2),
+                                Text(
+                                  l.seriesBooksBookCount(numBooks),
+                                  style: tt.labelSmall?.copyWith(
+                                    color: cs.onSurfaceVariant.withValues(
+                                      alpha: 0.5,
+                                    ),
+                                    fontSize: 11,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                   if (isExpanded)
-                    ...subBooks.map((book) => _buildBookCard(cs, tt, lib, book)),
+                    ...subBooks.map(
+                      (book) => _buildBookCard(cs, tt, lib, book),
+                    ),
                 ],
               ),
             );
@@ -577,7 +704,7 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
           _isLoading = false;
           _totalBooks = fetched.length;
         });
-        if (!_didAutoScroll) _scrollToUpNext();
+        _scrollToCurrentOrUpNext(allowFallback: true);
         try {
           lib.setSeriesBooksCache(seriesId, items, items.length);
         } catch (_) {}
@@ -600,13 +727,17 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
             _isLoading = false;
             _totalBooks = cachedTotal;
           });
-          _scrollToUpNext();
+          _scrollToCurrentOrUpNext(
+            allowFallback: fetched.length >= cachedTotal,
+          );
         }
       }
     }
 
     // Fetch fresh data (updates cache as pages arrive)
-    final data = await api.getSeries(seriesId, libraryId: libraryId,
+    final data = await api.getSeries(
+      seriesId,
+      libraryId: libraryId,
       onPageLoaded: (books, total, {double? totalDuration}) {
         if (!mounted) return;
         final fetched = _unwrapBooks(books);
@@ -615,12 +746,19 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
           _sortBooks();
           _isLoading = false;
           _totalBooks = total;
-          if (totalDuration != null && totalDuration > 0) _seriesDuration = totalDuration;
+          if (totalDuration != null && totalDuration > 0)
+            _seriesDuration = totalDuration;
         });
-        if (!_didAutoScroll) _scrollToUpNext();
+        _scrollToCurrentOrUpNext(allowFallback: fetched.length >= total);
         // Update cache - re-read lib safely, only cache non-empty results
         if (mounted && books.isNotEmpty) {
-          try { context.read<LibraryProvider>().setSeriesBooksCache(seriesId, books, total); } catch (_) {}
+          try {
+            context.read<LibraryProvider>().setSeriesBooksCache(
+              seriesId,
+              books,
+              total,
+            );
+          } catch (_) {}
         }
       },
     );
@@ -635,7 +773,6 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
       _loadSubSeriesData();
     }
   }
-
 
   bool get _allFinished {
     final lib = context.read<LibraryProvider>();
@@ -709,8 +846,14 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
         title: Text(l.seriesBooksFindMissingTitle),
         content: Text(l.seriesBooksFindMissingContent),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx, false), child: Text(l.cancel)),
-          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: Text(l.search)),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(l.search),
+          ),
         ],
       ),
     );
@@ -764,7 +907,10 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
         final auth = context.read<AuthProvider>();
         final api = auth.apiService;
         if (api != null) {
-          final results = await api.searchBooks(title: title, author: author.isNotEmpty ? author : null);
+          final results = await api.searchBooks(
+            title: title,
+            author: author.isNotEmpty ? author : null,
+          );
           for (final r in results) {
             final asin = r['asin'] as String? ?? '';
             if (asin.isEmpty) continue;
@@ -783,11 +929,16 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     if (!mounted) return;
 
     if (seriesAsin == null) {
-      showOverlayToast(context, l.seriesBooksCouldNotFindOnAudible, icon: Icons.search_off_rounded);
+      showOverlayToast(
+        context,
+        l.seriesBooksCouldNotFindOnAudible,
+        icon: Icons.search_off_rounded,
+      );
       return;
     }
 
-    showAudibleSeriesSheet(context,
+    showAudibleSeriesSheet(
+      context,
       seriesName: widget.seriesName,
       seriesAsin: seriesAsin,
       ownedTitles: ownedTitles,
@@ -810,7 +961,8 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
       return Padding(
         padding: const EdgeInsets.all(12),
         child: SizedBox(
-          width: 18, height: 18,
+          width: 18,
+          height: 18,
           child: CircularProgressIndicator(strokeWidth: 2, color: cs.primary),
         ),
       );
@@ -818,11 +970,23 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
 
     return IconButton(
       icon: Icon(Icons.more_vert_rounded, color: cs.onSurfaceVariant),
-      onPressed: () => _showSeriesMoreSheet(cs, allDownloaded, downloaded, allDone, hasSeriesId),
+      onPressed: () => _showSeriesMoreSheet(
+        cs,
+        allDownloaded,
+        downloaded,
+        allDone,
+        hasSeriesId,
+      ),
     );
   }
 
-  void _showSeriesMoreSheet(ColorScheme cs, bool allDownloaded, int downloaded, bool allDone, bool hasSeriesId) {
+  void _showSeriesMoreSheet(
+    ColorScheme cs,
+    bool allDownloaded,
+    int downloaded,
+    bool allDone,
+    bool hasSeriesId,
+  ) {
     final l = AppLocalizations.of(context)!;
     showModalBottomSheet(
       context: context,
@@ -834,73 +998,148 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
         return SafeArea(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-            child: Column(mainAxisSize: MainAxisSize.min, children: [
-              Center(child: Container(width: 40, height: 4, margin: const EdgeInsets.only(bottom: 16),
-                decoration: BoxDecoration(color: cs.onSurface.withValues(alpha: 0.24), borderRadius: BorderRadius.circular(2)))),
-              ActionPillGrid(items: [
-                if (!allDownloaded)
-                  ActionPillData(
-                    icon: Icons.download_rounded,
-                    label: downloaded > 0 ? l.downloadRemainingCount((_totalBooks > 0 ? _totalBooks : _books.length) - downloaded) : l.downloadAll,
-                    onTap: () { Navigator.pop(ctx); _downloadAll(); }),
-                ActionPillData(
-                  icon: allDone ? Icons.remove_done_rounded : Icons.done_all_rounded,
-                  label: allDone ? l.markAllNotFinished : l.markAllFinished,
-                  onTap: () async {
-                    Navigator.pop(ctx);
-                    if (allDone) {
-                      final confirmed = await showDialog<bool>(
-                        context: context,
-                        builder: (dlg) => AlertDialog(
-                          title: Text(l.markAllNotFinishedQuestion),
-                          content: Text(l.seriesBooksMarkAllNotFinishedContent(_books.length)),
-                          actions: [
-                            TextButton(onPressed: () => Navigator.pop(dlg, false), child: Text(l.cancel)),
-                            FilledButton(onPressed: () => Navigator.pop(dlg, true), child: Text(l.seriesBooksUnmarkAll)),
-                          ],
-                        ),
-                      );
-                      if (confirmed == true) _markAllNotFinished();
-                    } else {
-                      final confirmed = await showDialog<bool>(
-                        context: context,
-                        builder: (dlg) => AlertDialog(
-                          title: Text(Wording.of(context).fullyAbsorbSeries),
-                          content: Text(l.seriesBooksFullyAbsorbContent(_books.length)),
-                          actions: [
-                            TextButton(onPressed: () => Navigator.pop(dlg, false), child: Text(l.cancel)),
-                            FilledButton(onPressed: () => Navigator.pop(dlg, true), child: Text(Wording.of(context).fullyAbsorbAction)),
-                          ],
-                        ),
-                      );
-                      if (confirmed == true) _markAllFinished();
-                    }
-                  }),
-                if (hasSeriesId)
-                  ActionPillData(
-                    icon: _autoDownloadEnabled ? Icons.downloading_rounded : Icons.download_outlined,
-                    label: _autoDownloadEnabled ? l.turnAutoDownloadOff : l.turnAutoDownloadOn,
-                    onTap: () async {
-                      Navigator.pop(ctx);
-                      final lib = context.read<LibraryProvider>();
-                      await lib.toggleRollingDownload(widget.seriesId!,
-                          name: widget.seriesName, kind: 'series');
-                      setState(() => _autoDownloadEnabled = lib.isRollingDownloadEnabled(widget.seriesId!));
-                    }),
-                if (hasSeriesId)
-                  ActionPillData(
-                    icon: _scanExcluded ? Icons.visibility_rounded : Icons.visibility_off_rounded,
-                    label: _scanExcluded ? l.seriesIncludeInScan : l.seriesExcludeFromScan,
-                    onTap: () async {
-                      Navigator.pop(ctx);
-                      final next = !_scanExcluded;
-                      await UpcomingReleasesService.setNeverScan(widget.seriesId!, next);
-                      if (mounted) setState(() => _scanExcluded = next);
-                    }),
-                ActionPillData(icon: Icons.search_rounded, label: l.seriesBooksFindMissingTitle,
-                  onTap: () { Navigator.pop(ctx); _findOnAudible(); }),
-              ]),
-            ]),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    margin: const EdgeInsets.only(bottom: 16),
+                    decoration: BoxDecoration(
+                      color: cs.onSurface.withValues(alpha: 0.24),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                ActionPillGrid(
+                  items: [
+                    if (!allDownloaded)
+                      ActionPillData(
+                        icon: Icons.download_rounded,
+                        label: downloaded > 0
+                            ? l.downloadRemainingCount(
+                                (_totalBooks > 0
+                                        ? _totalBooks
+                                        : _books.length) -
+                                    downloaded,
+                              )
+                            : l.downloadAll,
+                        onTap: () {
+                          Navigator.pop(ctx);
+                          _downloadAll();
+                        },
+                      ),
+                    ActionPillData(
+                      icon: allDone
+                          ? Icons.remove_done_rounded
+                          : Icons.done_all_rounded,
+                      label: allDone ? l.markAllNotFinished : l.markAllFinished,
+                      onTap: () async {
+                        Navigator.pop(ctx);
+                        if (allDone) {
+                          final confirmed = await showDialog<bool>(
+                            context: context,
+                            builder: (dlg) => AlertDialog(
+                              title: Text(l.markAllNotFinishedQuestion),
+                              content: Text(
+                                l.seriesBooksMarkAllNotFinishedContent(
+                                  _books.length,
+                                ),
+                              ),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.pop(dlg, false),
+                                  child: Text(l.cancel),
+                                ),
+                                FilledButton(
+                                  onPressed: () => Navigator.pop(dlg, true),
+                                  child: Text(l.seriesBooksUnmarkAll),
+                                ),
+                              ],
+                            ),
+                          );
+                          if (confirmed == true) _markAllNotFinished();
+                        } else {
+                          final confirmed = await showDialog<bool>(
+                            context: context,
+                            builder: (dlg) => AlertDialog(
+                              title: Text(
+                                Wording.of(context).fullyAbsorbSeries,
+                              ),
+                              content: Text(
+                                l.seriesBooksFullyAbsorbContent(_books.length),
+                              ),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.pop(dlg, false),
+                                  child: Text(l.cancel),
+                                ),
+                                FilledButton(
+                                  onPressed: () => Navigator.pop(dlg, true),
+                                  child: Text(
+                                    Wording.of(context).fullyAbsorbAction,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                          if (confirmed == true) _markAllFinished();
+                        }
+                      },
+                    ),
+                    if (hasSeriesId)
+                      ActionPillData(
+                        icon: _autoDownloadEnabled
+                            ? Icons.downloading_rounded
+                            : Icons.download_outlined,
+                        label: _autoDownloadEnabled
+                            ? l.turnAutoDownloadOff
+                            : l.turnAutoDownloadOn,
+                        onTap: () async {
+                          Navigator.pop(ctx);
+                          final lib = context.read<LibraryProvider>();
+                          await lib.toggleRollingDownload(
+                            widget.seriesId!,
+                            name: widget.seriesName,
+                            kind: 'series',
+                          );
+                          setState(
+                            () => _autoDownloadEnabled = lib
+                                .isRollingDownloadEnabled(widget.seriesId!),
+                          );
+                        },
+                      ),
+                    if (hasSeriesId)
+                      ActionPillData(
+                        icon: _scanExcluded
+                            ? Icons.visibility_rounded
+                            : Icons.visibility_off_rounded,
+                        label: _scanExcluded
+                            ? l.seriesIncludeInScan
+                            : l.seriesExcludeFromScan,
+                        onTap: () async {
+                          Navigator.pop(ctx);
+                          final next = !_scanExcluded;
+                          await UpcomingReleasesService.setNeverScan(
+                            widget.seriesId!,
+                            next,
+                          );
+                          if (mounted) setState(() => _scanExcluded = next);
+                        },
+                      ),
+                    ActionPillData(
+                      icon: Icons.search_rounded,
+                      label: l.seriesBooksFindMissingTitle,
+                      onTap: () {
+                        Navigator.pop(ctx);
+                        _findOnAudible();
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         );
       },
@@ -922,15 +1161,24 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
           title: Text(l.autoDownloadThisSeries),
           content: Text(l.autoDownloadSeriesContent),
           actions: [
-            TextButton(onPressed: () => Navigator.pop(ctx, false), child: Text(l.noThanks)),
-            FilledButton(onPressed: () => Navigator.pop(ctx, true), child: Text(l.enable)),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(l.noThanks),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: Text(l.enable),
+            ),
           ],
         ),
       );
       if (enable == true && mounted) {
         final lib = context.read<LibraryProvider>();
-        await lib.enableRollingDownload(seriesId,
-            name: widget.seriesName, kind: 'series');
+        await lib.enableRollingDownload(
+          seriesId,
+          name: widget.seriesName,
+          kind: 'series',
+        );
         setState(() => _autoDownloadEnabled = true);
       }
     }
@@ -942,7 +1190,9 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     for (final book in _books) {
       if (!mounted) break;
       final bookId = book['id'] as String? ?? '';
-      if (DownloadService().isDownloaded(bookId) || DownloadService().isDownloading(bookId)) continue;
+      if (DownloadService().isDownloaded(bookId) ||
+          DownloadService().isDownloading(bookId))
+        continue;
 
       final media = book['media'] as Map<String, dynamic>? ?? {};
       final metadata = media['metadata'] as Map<String, dynamic>? ?? {};
@@ -975,199 +1225,262 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     for (final book in _books) {
       final bookId = book['id'] as String? ?? '';
       final media = book['media'] as Map<String, dynamic>? ?? {};
-      final dur = (media['duration'] is num) ? (media['duration'] as num).toDouble() : 0.0;
+      final dur = (media['duration'] is num)
+          ? (media['duration'] as num).toDouble()
+          : 0.0;
       final prog = lib.getProgress(bookId);
       totalDuration += dur;
       listenedDuration += dur * prog;
     }
-    final seriesProgress = totalDuration > 0 ? (listenedDuration / totalDuration).clamp(0.0, 1.0) : 0.0;
+    final seriesProgress = totalDuration > 0
+        ? (listenedDuration / totalDuration).clamp(0.0, 1.0)
+        : 0.0;
     final seriesPercent = (seriesProgress * 100).round();
 
-    return ClipRect(child: Column(
-      children: [
-        // Header row: 3-dot menu pinned top-right
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const SizedBox(width: 48),
-            Expanded(
-              child: Column(
-                children: [
-                  Icon(Icons.auto_stories_rounded, size: 20, color: cs.primary),
-                  const SizedBox(height: 4),
-                  Text(widget.seriesName,
+    return ClipRect(
+      child: Column(
+        children: [
+          // Header row: 3-dot menu pinned top-right
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(width: 48),
+              Expanded(
+                child: Column(
+                  children: [
+                    Icon(
+                      Icons.auto_stories_rounded,
+                      size: 20,
+                      color: cs.primary,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      widget.seriesName,
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       textAlign: TextAlign.center,
-                      style: tt.titleLarge
-                          ?.copyWith(fontWeight: FontWeight.w600)),
+                      style: tt.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                width: 48,
+                child: _books.isNotEmpty ? _buildOverflowMenu(cs) : null,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(
+                  text: () {
+                    final displayDuration = _seriesDuration > totalDuration
+                        ? _seriesDuration
+                        : totalDuration;
+                    final bookCount = _totalBooks > 0
+                        ? _totalBooks
+                        : _books.length;
+                    final base = l.booksInSeriesCount(bookCount);
+                    return displayDuration > 0
+                        ? '$base · ${formatHm(displayDuration)}'
+                        : base;
+                  }(),
+                ),
+                if (_autoDownloadEnabled) ...[
+                  const TextSpan(text: ' · '),
+                  WidgetSpan(
+                    alignment: PlaceholderAlignment.middle,
+                    child: Icon(
+                      Icons.downloading_rounded,
+                      size: 14,
+                      color: cs.primary,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          ),
+          SizedBox(height: seriesProgress > 0 ? 4 : 12),
+          if (seriesProgress > 0)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(2),
+                      child: LinearProgressIndicator(
+                        value: seriesProgress,
+                        minHeight: 4,
+                        backgroundColor: cs.surfaceContainerHighest,
+                        valueColor: AlwaysStoppedAnimation(cs.primary),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Text(
+                    l.percentComplete(seriesPercent.toString()),
+                    style: tt.labelSmall?.copyWith(
+                      color: cs.primary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
                 ],
               ),
             ),
-            SizedBox(
-              width: 48,
-              child: _books.isNotEmpty ? _buildOverflowMenu(cs) : null,
-            ),
-          ],
-        ),
-        const SizedBox(height: 4),
-        Text.rich(
-          TextSpan(
-            children: [
-              TextSpan(
-                text: () {
-                  final displayDuration = _seriesDuration > totalDuration ? _seriesDuration : totalDuration;
-                  final bookCount = _totalBooks > 0 ? _totalBooks : _books.length;
-                  final base = l.booksInSeriesCount(bookCount);
-                  return displayDuration > 0
-                      ? '$base · ${formatHm(displayDuration)}'
-                      : base;
-                }(),
+          if (_books.isNotEmpty)
+            sheetViewModeBar(
+              context,
+              gridView: _gridView,
+              onChanged: (grid) => setState(() => _gridView = grid),
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              leading: IconButton(
+                icon: Icon(
+                  Icons.collections_bookmark_rounded,
+                  size: 20,
+                  color: _collapseSeries ? cs.primary : cs.onSurfaceVariant,
+                ),
+                visualDensity: VisualDensity.compact,
+                tooltip: _collapseSeries
+                    ? l.seriesBooksShowAllBooks
+                    : l.seriesBooksGroupBySubSeries,
+                onPressed: () {
+                  setState(() {
+                    _collapseSeries = !_collapseSeries;
+                    if (_collapseSeries) {
+                      _expandedSubSeries.clear();
+                      if (!_subSeriesLoaded) _loadSubSeriesData();
+                    }
+                  });
+                  PlayerSettings.setCollapseBookSeries(_collapseSeries);
+                },
               ),
-              if (_autoDownloadEnabled) ...[
-                const TextSpan(text: ' · '),
-                WidgetSpan(
-                  alignment: PlaceholderAlignment.middle,
-                  child: Icon(Icons.downloading_rounded, size: 14, color: cs.primary),
-                ),
-              ],
-            ],
-          ),
-          style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
-        ),
-        SizedBox(height: seriesProgress > 0 ? 4 : 12),
-        if (seriesProgress > 0)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
-            child: Row(
-              children: [
-                Expanded(
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(2),
-                    child: LinearProgressIndicator(
-                      value: seriesProgress,
-                      minHeight: 4,
-                      backgroundColor: cs.surfaceContainerHighest,
-                      valueColor: AlwaysStoppedAnimation(cs.primary),
+            ),
+          if (_isLoading && _books.isEmpty)
+            const Expanded(child: Center(child: CircularProgressIndicator()))
+          else if (_books.isEmpty && _loadFailed)
+            Expanded(
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      l.failedToLoad,
+                      style: tt.bodyLarge?.copyWith(color: cs.onSurfaceVariant),
                     ),
+                    TextButton(
+                      onPressed: () {
+                        setState(() {
+                          _isLoading = true;
+                          _loadFailed = false;
+                        });
+                        _fetchFromApi();
+                      },
+                      child: Text(l.retry),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          else if (_books.isEmpty)
+            Expanded(
+              child: Center(
+                child: Text(
+                  l.noBooksFound,
+                  style: tt.bodyLarge?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              ),
+            )
+          else if (_collapseSeries && !_subSeriesLoaded)
+            Expanded(
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const CircularProgressIndicator(strokeWidth: 2),
+                    const SizedBox(height: 12),
+                    Text(
+                      l.seriesBooksLoadingSubSeries,
+                      style: tt.bodySmall?.copyWith(
+                        color: cs.onSurface.withValues(alpha: 0.4),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          else if (_collapseSeries && _gridView)
+            Expanded(
+              child: ListenableBuilder(
+                listenable: DownloadService(),
+                builder: (context, _) => _buildGroupedGrid(cs, tt, lib),
+              ),
+            )
+          else if (_collapseSeries)
+            Expanded(
+              child: ListenableBuilder(
+                listenable: DownloadService(),
+                builder: (context, _) => _buildGroupedList(cs, tt, lib),
+              ),
+            )
+          else if (_gridView)
+            Expanded(
+              child: ListenableBuilder(
+                listenable: DownloadService(),
+                builder: (context, _) => GridView.builder(
+                  controller: widget.scrollController,
+                  padding: EdgeInsets.fromLTRB(
+                    16,
+                    0,
+                    16,
+                    24 + MediaQuery.of(context).viewPadding.bottom,
+                  ),
+                  gridDelegate: sheetBookGridDelegate(
+                    context,
+                    childAspectRatio: 0.65,
+                  ),
+                  itemCount: _books.length,
+                  itemBuilder: (context, index) => GridBookTile(
+                    item: _books[index],
+                    sequenceBadge: _getSequenceString(_books[index]),
                   ),
                 ),
-                const SizedBox(width: 10),
-                Text(
-                  l.percentComplete(seriesPercent.toString()),
-                  style: tt.labelSmall?.copyWith(
-                    color: cs.primary,
-                    fontWeight: FontWeight.w600,
+              ),
+            )
+          else
+            Expanded(
+              child: ListenableBuilder(
+                listenable: DownloadService(),
+                builder: (context, _) => ListView.builder(
+                  controller: widget.scrollController,
+                  padding: EdgeInsets.fromLTRB(
+                    16,
+                    0,
+                    16,
+                    24 + MediaQuery.of(context).viewPadding.bottom,
                   ),
+                  itemCount: _books.length,
+                  itemBuilder: (context, index) =>
+                      _buildBookCard(cs, tt, lib, _books[index]),
                 ),
-              ],
+              ),
             ),
-          ),
-        if (_books.isNotEmpty)
-          sheetViewModeBar(
-            context,
-            gridView: _gridView,
-            onChanged: (grid) => setState(() => _gridView = grid),
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            leading: IconButton(
-              icon: Icon(Icons.collections_bookmark_rounded, size: 20,
-                color: _collapseSeries ? cs.primary : cs.onSurfaceVariant),
-              visualDensity: VisualDensity.compact,
-              tooltip: _collapseSeries ? l.seriesBooksShowAllBooks : l.seriesBooksGroupBySubSeries,
-              onPressed: () {
-                setState(() {
-                  _collapseSeries = !_collapseSeries;
-                  if (_collapseSeries) {
-                    _expandedSubSeries.clear();
-                    if (!_subSeriesLoaded) _loadSubSeriesData();
-                  }
-                });
-                PlayerSettings.setCollapseBookSeries(_collapseSeries);
-              },
-            ),
-          ),
-        if (_isLoading && _books.isEmpty)
-          const Expanded(
-              child: Center(child: CircularProgressIndicator()))
-        else if (_books.isEmpty && _loadFailed)
-          Expanded(
-            child: Center(
-              child: Column(mainAxisSize: MainAxisSize.min, children: [
-                Text(l.failedToLoad,
-                    style: tt.bodyLarge
-                        ?.copyWith(color: cs.onSurfaceVariant)),
-                TextButton(
-                  onPressed: () {
-                    setState(() {
-                      _isLoading = true;
-                      _loadFailed = false;
-                    });
-                    _fetchFromApi();
-                  },
-                  child: Text(l.retry),
-                ),
-              ]),
-            ),
-          )
-        else if (_books.isEmpty)
-          Expanded(
-            child: Center(
-              child: Text(l.noBooksFound,
-                  style: tt.bodyLarge
-                      ?.copyWith(color: cs.onSurfaceVariant)),
-            ),
-          )
-        else if (_collapseSeries && !_subSeriesLoaded)
-          Expanded(
-            child: Center(child: Column(mainAxisSize: MainAxisSize.min, children: [
-              const CircularProgressIndicator(strokeWidth: 2),
-              const SizedBox(height: 12),
-              Text(l.seriesBooksLoadingSubSeries, style: tt.bodySmall?.copyWith(color: cs.onSurface.withValues(alpha: 0.4))),
-            ])),
-          )
-        else if (_collapseSeries && _gridView)
-          Expanded(
-            child: ListenableBuilder(
-              listenable: DownloadService(),
-              builder: (context, _) => _buildGroupedGrid(cs, tt, lib),
-            ),
-          )
-        else if (_collapseSeries)
-          Expanded(
-            child: ListenableBuilder(
-              listenable: DownloadService(),
-              builder: (context, _) => _buildGroupedList(cs, tt, lib),
-            ),
-          )
-        else if (_gridView)
-          Expanded(
-            child: ListenableBuilder(
-              listenable: DownloadService(),
-              builder: (context, _) => GridView.builder(
-              controller: widget.scrollController,
-              padding: EdgeInsets.fromLTRB(16, 0, 16, 24 + MediaQuery.of(context).viewPadding.bottom),
-              gridDelegate: sheetBookGridDelegate(context, childAspectRatio: 0.65),
-              itemCount: _books.length,
-              itemBuilder: (context, index) => GridBookTile(item: _books[index], sequenceBadge: _getSequenceString(_books[index])),
-            ),
-          ))
-        else
-          Expanded(
-            child: ListenableBuilder(
-              listenable: DownloadService(),
-              builder: (context, _) => ListView.builder(
-              controller: widget.scrollController,
-              padding: EdgeInsets.fromLTRB(16, 0, 16, 24 + MediaQuery.of(context).viewPadding.bottom),
-              itemCount: _books.length,
-              itemBuilder: (context, index) => _buildBookCard(cs, tt, lib, _books[index]),
-            ),
-          ),
-          ),
-      ],
-    ));
+        ],
+      ),
+    );
   }
 
-  Widget _buildBookCard(ColorScheme cs, TextTheme tt, LibraryProvider lib, Map<String, dynamic> book) {
+  Widget _buildBookCard(
+    ColorScheme cs,
+    TextTheme tt,
+    LibraryProvider lib,
+    Map<String, dynamic> book,
+  ) {
     final l = AppLocalizations.of(context)!;
     final bookId = book['id'] as String? ?? '';
     final media = book['media'] as Map<String, dynamic>? ?? {};
@@ -1175,14 +1488,19 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     final bookTitle = metadata['title'] as String? ?? l.unknown;
     final authorName = metadata['authorName'] as String? ?? '';
     final sequence = _getSequenceString(book);
-    final duration = (media['duration'] is num) ? (media['duration'] as num).toDouble() : 0.0;
+    final duration = (media['duration'] is num)
+        ? (media['duration'] as num).toDouble()
+        : 0.0;
 
-    final isExplicit = PlayerSettings.showExplicitBadge && metadata['explicit'] == true;
+    final isExplicit =
+        PlayerSettings.showExplicitBadge && metadata['explicit'] == true;
     final progress = lib.getProgress(bookId);
     final isFinished = lib.getProgressData(bookId)?['isFinished'] == true;
     final isDownloaded = DownloadService().isDownloaded(bookId);
     final isDownloading = DownloadService().isDownloading(bookId);
-    final downloadPct = (DownloadService().downloadProgress(bookId) * 100).clamp(0, 100).round();
+    final downloadPct = (DownloadService().downloadProgress(bookId) * 100)
+        .clamp(0, 100)
+        .round();
     final coverUrl = lib.getCoverUrl(bookId);
     final isOnAbsorbing = lib.isOnAbsorbingList(bookId);
 
@@ -1197,17 +1515,27 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
                 color: cs.primary,
                 onTrigger: () async {
                   await lib.addToAbsorbingQueue(bookId);
-                  lib.absorbingItemCache[bookId] = Map<String, dynamic>.from(book);
+                  lib.absorbingItemCache[bookId] = Map<String, dynamic>.from(
+                    book,
+                  );
                   if (context.mounted) {
                     HapticFeedback.mediumImpact();
-                    showOverlayToast(context, Wording.of(context).episodeListAddedToAbsorbing(bookTitle), icon: Icons.add_circle_outline_rounded);
+                    showOverlayToast(
+                      context,
+                      Wording.of(
+                        context,
+                      ).episodeListAddedToAbsorbing(bookTitle),
+                      icon: Icons.add_circle_outline_rounded,
+                    );
                   }
                 },
               ),
         child: Card(
           elevation: 0,
           color: cs.surfaceContainerHigh,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
           clipBehavior: Clip.antiAlias,
           child: InkWell(
             onTap: () {
@@ -1222,90 +1550,200 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
             borderRadius: BorderRadius.circular(14),
             child: SizedBox(
               height: 112,
-              child: Row(children: [
-                AspectRatio(
-                  aspectRatio: 1,
-                  child: Stack(children: [
-                    Positioned.fill(
-                      child: coverUrl != null
-                          ? (coverUrl.startsWith('/')
-                              ? Image.file(File(coverUrl), fit: BoxFit.cover,
-                                  errorBuilder: (_, __, ___) => _placeholder(cs))
-                              : CachedNetworkImage(
-                                  imageUrl: coverUrl, fit: BoxFit.cover,
-                                  httpHeaders: lib.mediaHeaders,
-                                  placeholder: (_, __) => _placeholder(cs),
-                                  errorWidget: (_, __, ___) => _placeholder(cs)))
-                          : _placeholder(cs),
+              child: Row(
+                children: [
+                  AspectRatio(
+                    aspectRatio: 1,
+                    child: Stack(
+                      children: [
+                        Positioned.fill(
+                          child: coverUrl != null
+                              ? (coverUrl.startsWith('/')
+                                    ? Image.file(
+                                        File(coverUrl),
+                                        fit: BoxFit.cover,
+                                        errorBuilder: (_, __, ___) =>
+                                            _placeholder(cs),
+                                      )
+                                    : CachedNetworkImage(
+                                        imageUrl: coverUrl,
+                                        fit: BoxFit.cover,
+                                        httpHeaders: lib.mediaHeaders,
+                                        placeholder: (_, __) =>
+                                            _placeholder(cs),
+                                        errorWidget: (_, __, ___) =>
+                                            _placeholder(cs),
+                                      ))
+                              : _placeholder(cs),
+                        ),
+                        if (sequence != null && sequence.isNotEmpty)
+                          Positioned(
+                            top: 4,
+                            left: 4,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 5,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.black.withValues(alpha: 0.7),
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Text(
+                                '#$sequence',
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 9,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          ),
+                        if (isExplicit)
+                          Positioned(
+                            top: 4,
+                            right: 4,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 4,
+                                vertical: 1,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.red.withValues(alpha: 0.85),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: Text(
+                                l.seriesBooksExplicitBadge,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 9,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                            ),
+                          ),
+                        if (!isDownloaded && isDownloading)
+                          Positioned(
+                            top: isExplicit ? 22 : 4,
+                            right: 4,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 6,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.black54,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Text(
+                                '$downloadPct%',
+                                style: TextStyle(
+                                  color: cs.primary,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ),
+                          ),
+                        if (progress > 0 && !isFinished)
+                          Positioned(
+                            left: 0,
+                            right: 0,
+                            bottom: 0,
+                            child: LinearProgressIndicator(
+                              value: progress.clamp(0.0, 1.0),
+                              minHeight: 3,
+                              backgroundColor: Colors.black38,
+                              valueColor: AlwaysStoppedAnimation(cs.primary),
+                            ),
+                          ),
+                        if (isFinished || isDownloaded)
+                          Positioned(
+                            left: 0,
+                            right: 0,
+                            bottom: 0,
+                            child: CoverStateBadges(
+                              isDownloaded: isDownloaded,
+                              isFinished: isFinished,
+                            ),
+                          ),
+                      ],
                     ),
-                    if (sequence != null && sequence.isNotEmpty)
-                      Positioned(top: 4, left: 4,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
-                          decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.7), borderRadius: BorderRadius.circular(6)),
-                          child: Text('#$sequence', style: const TextStyle(color: Colors.white, fontSize: 9, fontWeight: FontWeight.w600)),
-                        ),
-                      ),
-                    if (isExplicit)
-                      Positioned(top: 4, right: 4,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-                          decoration: BoxDecoration(color: Colors.red.withValues(alpha: 0.85), borderRadius: BorderRadius.circular(4)),
-                          child: Text(l.seriesBooksExplicitBadge, style: const TextStyle(color: Colors.white, fontSize: 9, fontWeight: FontWeight.w800)),
-                        ),
-                      ),
-                    if (!isDownloaded && isDownloading)
-                      Positioned(top: isExplicit ? 22 : 4, right: 4,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                          decoration: BoxDecoration(color: Colors.black54, borderRadius: BorderRadius.circular(6)),
-                          child: Text('$downloadPct%', style: TextStyle(color: cs.primary, fontSize: 10, fontWeight: FontWeight.w700)),
-                        ),
-                      ),
-                    if (progress > 0 && !isFinished)
-                      Positioned(left: 0, right: 0, bottom: 0,
-                        child: LinearProgressIndicator(
-                          value: progress.clamp(0.0, 1.0), minHeight: 3,
-                          backgroundColor: Colors.black38, valueColor: AlwaysStoppedAnimation(cs.primary)),
-                      ),
-                    if (isFinished || isDownloaded)
-                      Positioned(left: 0, right: 0, bottom: 0,
-                        child: CoverStateBadges(isDownloaded: isDownloaded, isFinished: isFinished),
-                      ),
-                  ]),
-                ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                    child: Column(crossAxisAlignment: CrossAxisAlignment.start, mainAxisAlignment: MainAxisAlignment.center, children: [
-                      if (sequence != null && sequence.isNotEmpty)
-                        Text(l.bookNumber(sequence), style: tt.labelSmall?.copyWith(color: cs.primary, fontWeight: FontWeight.w600)),
-                      Text(bookTitle, maxLines: 2, overflow: TextOverflow.ellipsis,
-                        style: tt.titleSmall?.copyWith(fontWeight: FontWeight.w600, color: cs.onSurface)),
-                      if (authorName.isNotEmpty) ...[
-                        const SizedBox(height: 2),
-                        Text(authorName, maxLines: 1, overflow: TextOverflow.ellipsis,
-                          style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant)),
-                      ],
-                      if (duration > 0) ...[
-                        const SizedBox(height: 2),
-                        Row(children: [
-                          Text(formatHm(duration), style: tt.labelSmall?.copyWith(color: cs.onSurfaceVariant)),
-                          if (progress > 0 && !isFinished) ...[
-                            const SizedBox(width: 8),
-                            Text('${(progress * 100).round()}%',
-                              style: tt.labelSmall?.copyWith(color: cs.primary, fontWeight: FontWeight.w600)),
-                          ],
-                        ]),
-                      ],
-                    ]),
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(right: 12),
-                  child: Icon(Icons.chevron_right_rounded, color: cs.onSurfaceVariant),
-                ),
-              ]),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 10,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          if (sequence != null && sequence.isNotEmpty)
+                            Text(
+                              l.bookNumber(sequence),
+                              style: tt.labelSmall?.copyWith(
+                                color: cs.primary,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          Text(
+                            bookTitle,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: tt.titleSmall?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: cs.onSurface,
+                            ),
+                          ),
+                          if (authorName.isNotEmpty) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              authorName,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: tt.bodySmall?.copyWith(
+                                color: cs.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                          if (duration > 0) ...[
+                            const SizedBox(height: 2),
+                            Row(
+                              children: [
+                                Text(
+                                  formatHm(duration),
+                                  style: tt.labelSmall?.copyWith(
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                                ),
+                                if (progress > 0 && !isFinished) ...[
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    '${(progress * 100).round()}%',
+                                    style: tt.labelSmall?.copyWith(
+                                      color: cs.primary,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(right: 12),
+                    child: Icon(
+                      Icons.chevron_right_rounded,
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -1317,10 +1755,12 @@ class _SeriesBooksSheetState extends State<SeriesBooksSheet> {
     return Container(
       color: cs.surfaceContainerHighest,
       child: Center(
-        child: Icon(Icons.headphones_rounded,
-            size: 24, color: cs.onSurfaceVariant.withValues(alpha: 0.4)),
+        child: Icon(
+          Icons.headphones_rounded,
+          size: 24,
+          color: cs.onSurfaceVariant.withValues(alpha: 0.4),
+        ),
       ),
     );
   }
-
 }


### PR DESCRIPTION
## Summary
- fetch complete series lists instead of truncating them at 100 books, so auto-download and series navigation work for long series
- focus the currently playing book when opening a series from Manage Queue or Library
- defer the Library-series fallback target until paginated results are complete
- add the AndroidX Media dependency required by the Android media integration

## Verification
- `flutter build apk --flavor github --release`
- manually verified a 239-book series: Manage Queue and Library now focus the active book (book 171)